### PR TITLE
Add interactive Finace David dashboard website

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Finace David — Dashboard Financeira</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <span class="logo">FD</span>
+          <div>
+            <strong>Finace David</strong>
+            <small>Gestão premium</small>
+          </div>
+        </div>
+        <nav class="sidebar-nav">
+          <a href="#" class="active">
+            <span>Dashboard</span>
+            <small>Visão geral</small>
+          </a>
+          <a href="#">
+            <span>Transações</span>
+            <small>Histórico completo</small>
+          </a>
+          <a href="#">
+            <span>Contas</span>
+            <small>Pagamentos e cobranças</small>
+          </a>
+          <a href="#">
+            <span>Relatórios</span>
+            <small>Insights avançados</small>
+          </a>
+        </nav>
+        <div class="sidebar-footer">
+          <p>Atualizado há <strong>2 minutos</strong>.</p>
+          <button class="btn-outline">Exportar Relatório</button>
+        </div>
+      </aside>
+      <main class="content">
+        <header class="top-bar">
+          <div>
+            <h1>Central Financeira</h1>
+            <p class="subtitle">Acompanhe entradas, saídas e compromissos em tempo real.</p>
+          </div>
+          <div class="top-actions">
+            <button class="btn-ghost" id="themeToggle" aria-label="Alternar tema">
+              <span class="icon">🌙</span>
+            </button>
+            <div class="profile-card">
+              <div class="avatar">D</div>
+              <div>
+                <strong>David Breno</strong>
+                <small>Diretor Financeiro</small>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section class="quick-links" aria-label="Seletor de visão">
+          <button class="quick-link active" data-view="resumo">
+            <span class="icon">📊</span>
+            Resumo
+          </button>
+          <button class="quick-link" data-view="entrada">
+            <span class="icon">⬆️</span>
+            Entrada
+          </button>
+          <button class="quick-link" data-view="saida">
+            <span class="icon">⬇️</span>
+            Saída
+          </button>
+          <button class="quick-link" data-view="contas">
+            <span class="icon">📅</span>
+            Contas a pagar
+          </button>
+        </section>
+
+        <section class="cards" aria-label="Indicadores principais">
+          <article class="card" data-card="saldo">
+            <header>
+              <span class="label">Saldo atual</span>
+              <span class="pill positive">▲ <span data-field="saldoVariation">+8,3%</span></span>
+            </header>
+            <div class="value" data-field="saldoValue">R$ 185.420,32</div>
+            <footer>
+              <span>Disponível em caixa</span>
+              <span class="secondary">Atualizado hoje</span>
+            </footer>
+          </article>
+          <article class="card" data-card="entradas">
+            <header>
+              <span class="label">Entradas</span>
+              <span class="pill positive">▲ <span data-field="entradaVariation">+12,4%</span></span>
+            </header>
+            <div class="value" data-field="entradaValue">R$ 72.900,00</div>
+            <footer>
+              <span>Ticket médio</span>
+              <span class="secondary" data-field="entradaAverage">R$ 3.040,00</span>
+            </footer>
+          </article>
+          <article class="card" data-card="saidas">
+            <header>
+              <span class="label">Saídas</span>
+              <span class="pill negative">▼ <span data-field="saidaVariation">-4,1%</span></span>
+            </header>
+            <div class="value" data-field="saidaValue">R$ 38.450,00</div>
+            <footer>
+              <span>Principais centros</span>
+              <span class="secondary" data-field="saidaTop">Marketing, Operações</span>
+            </footer>
+          </article>
+          <article class="card" data-card="contas">
+            <header>
+              <span class="label">Contas a pagar</span>
+              <span class="pill warning">⚠ <span data-field="contasDue">3 vencendo</span></span>
+            </header>
+            <div class="value" data-field="contasValue">R$ 24.230,00</div>
+            <footer>
+              <span>Agendadas para esta semana</span>
+              <span class="secondary" data-field="contasNext">Folha, Software, Energia</span>
+            </footer>
+          </article>
+        </section>
+
+        <section class="grid">
+          <article class="panel chart" aria-label="Desempenho mensal">
+            <header>
+              <div>
+                <h2 id="lineChartTitle">Evolução de entradas e saídas</h2>
+                <p class="secondary" id="lineChartSubtitle">Últimos 12 meses</p>
+              </div>
+              <div class="chip-group" role="group" aria-label="Escala temporal">
+                <button class="chip active" data-range="12">12 meses</button>
+                <button class="chip" data-range="6">6 meses</button>
+                <button class="chip" data-range="3">3 meses</button>
+              </div>
+            </header>
+            <canvas id="lineChart" height="220" role="img" aria-label="Gráfico de linhas com evolução financeira"></canvas>
+          </article>
+
+          <article class="panel chart" aria-label="Distribuição por categoria">
+            <header>
+              <div>
+                <h2 id="donutChartTitle">Distribuição por categoria</h2>
+                <p class="secondary" id="donutChartSubtitle">Top categorias</p>
+              </div>
+            </header>
+            <canvas id="donutChart" height="220" role="img" aria-label="Gráfico em rosca com distribuição"></canvas>
+          </article>
+
+          <article class="panel calendar" aria-label="Calendário financeiro">
+            <header>
+              <div>
+                <h2>Calendário inteligente</h2>
+                <p class="secondary">Clique nos dias para ver detalhes</p>
+              </div>
+              <div class="calendar-nav">
+                <button class="btn-ghost" id="prevMonth" aria-label="Mês anterior">◀</button>
+                <span id="calendarMonth" aria-live="polite">Abril 2025</span>
+                <button class="btn-ghost" id="nextMonth" aria-label="Próximo mês">▶</button>
+              </div>
+            </header>
+            <div class="calendar-grid" role="grid" aria-labelledby="calendarMonth"></div>
+            <div class="calendar-legend">
+              <span><i class="dot positive"></i>Entrada</span>
+              <span><i class="dot negative"></i>Saída</span>
+              <span><i class="dot warning"></i>Conta a pagar</span>
+            </div>
+            <div class="calendar-details" aria-live="polite">
+              <h3>Detalhes do dia</h3>
+              <ul id="calendarDetails"></ul>
+            </div>
+          </article>
+
+          <article class="panel activity" aria-label="Linha do tempo de atividades">
+            <header>
+              <div>
+                <h2>Últimos movimentos</h2>
+                <p class="secondary">Atualizado continuamente</p>
+              </div>
+            </header>
+            <ul class="timeline" id="activityTimeline"></ul>
+          </article>
+        </section>
+      </main>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" integrity="sha384-wFkcoFszhWnWoL4+tT7xAODTixLBlv9wlHFugNPVJzkLTmNdzpyQkfmc52Uz9J28" crossorigin="anonymous"></script>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,601 @@
+const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+  minimumFractionDigits: 2,
+});
+
+const percentFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+function formatCurrency(value) {
+  return currencyFormatter.format(value);
+}
+
+function formatPercent(value) {
+  const formatted = percentFormatter.format(Math.abs(value));
+  return `${value >= 0 ? '+' : '-'}${formatted}`;
+}
+
+function createMonthlyLabels(count) {
+  const labels = [];
+  const base = new Date();
+  for (let i = count - 1; i >= 0; i -= 1) {
+    const date = new Date(base.getFullYear(), base.getMonth() - i, 1);
+    labels.push(
+      new Intl.DateTimeFormat('pt-BR', { month: 'short' })
+        .format(date)
+        .replace('.', '')
+    );
+  }
+  return labels;
+}
+
+const monthlyLabels = createMonthlyLabels(12);
+
+const financeData = {
+  resumo: {
+    highlightCard: null,
+    titles: {
+      lineTitle: 'Evolução de entradas e saídas',
+      lineSubtitle: 'Últimos 12 meses',
+      donutTitle: 'Composição de receitas e despesas',
+      donutSubtitle: 'Distribuição consolidada',
+    },
+    cards: {
+      saldoValue: { type: 'currency', value: 185420.32 },
+      saldoVariation: { type: 'percent', value: 0.083 },
+      entradaValue: { type: 'currency', value: 72900 },
+      entradaVariation: { type: 'percent', value: 0.124 },
+      entradaAverage: { type: 'currency', value: 3040 },
+      saidaValue: { type: 'currency', value: 38450 },
+      saidaVariation: { type: 'percent', value: -0.041 },
+      saidaTop: { type: 'text', value: 'Marketing, Operações' },
+      contasValue: { type: 'currency', value: 24230 },
+      contasDue: { type: 'text', value: '3 vencendo' },
+      contasNext: { type: 'text', value: 'Folha, Software, Energia' },
+    },
+    line: {
+      labels: monthlyLabels,
+      datasets: [
+        {
+          label: 'Entradas',
+          data: [42000, 43200, 44500, 46800, 48120, 50210, 51980, 53870, 55240, 56910, 58900, 61240],
+          borderColor: 'rgba(16, 185, 129, 1)',
+          backgroundColor: 'rgba(16, 185, 129, 0.2)',
+          tension: 0.4,
+          fill: true,
+        },
+        {
+          label: 'Saídas',
+          data: [27500, 29200, 30550, 32100, 33450, 34900, 35220, 36110, 36840, 37250, 37800, 38450],
+          borderColor: 'rgba(248, 113, 113, 1)',
+          backgroundColor: 'rgba(248, 113, 113, 0.18)',
+          tension: 0.4,
+          fill: true,
+        },
+      ],
+    },
+    donut: {
+      labels: ['Consultorias', 'Investimentos', 'Produtos digitais', 'Serviços recorrentes'],
+      data: [32000, 19000, 14500, 7400],
+      colors: ['#10b981', '#6366f1', '#f97316', '#ec4899'],
+    },
+    events: [
+      { date: '2025-04-02', type: 'entrada', title: 'Consultoria XPTO', amount: 8200 },
+      { date: '2025-04-03', type: 'contas', title: 'Folha de pagamento', amount: 15800 },
+      { date: '2025-04-04', type: 'saida', title: 'Campanha de mídia', amount: 6200 },
+      { date: '2025-04-08', type: 'entrada', title: 'Licenças anuais', amount: 12400 },
+      { date: '2025-04-09', type: 'contas', title: 'Software ERP', amount: 3400 },
+      { date: '2025-04-10', type: 'saida', title: 'Infraestrutura cloud', amount: 4100 },
+      { date: '2025-04-15', type: 'entrada', title: 'Mentoria executiva', amount: 5300 },
+      { date: '2025-04-17', type: 'contas', title: 'Energia elétrica', amount: 1870 },
+      { date: '2025-04-18', type: 'saida', title: 'Treinamento time', amount: 2200 },
+      { date: '2025-04-22', type: 'entrada', title: 'Royalties plataforma', amount: 9100 },
+      { date: '2025-04-24', type: 'saida', title: 'Serviços jurídicos', amount: 1800 },
+      { date: '2025-04-26', type: 'contas', title: 'Impostos municipais', amount: 4600 },
+    ],
+    timeline: [
+      { title: 'Entrada confirmada', detail: 'Consultoria XPTO', type: 'entrada', amount: 8200, time: 'há 8 minutos' },
+      { title: 'Conta paga', detail: 'Energia elétrica', type: 'contas', amount: -1870, time: 'há 34 minutos' },
+      { title: 'Revisão de orçamento', detail: 'Marketing atualizado', type: 'saida', amount: -2100, time: 'há 1 hora' },
+      { title: 'Projeção mensal', detail: 'Saldo previsto ajustado', type: 'entrada', amount: 0, time: 'há 2 horas' },
+    ],
+  },
+  entrada: {
+    highlightCard: 'entradas',
+    titles: {
+      lineTitle: 'Entradas confirmadas',
+      lineSubtitle: 'Fluxo de recebimentos',
+      donutTitle: 'Receitas por origem',
+      donutSubtitle: 'Top 4 contratos',
+    },
+    cards: {
+      saldoValue: { type: 'currency', value: 185420.32 },
+      saldoVariation: { type: 'percent', value: 0.083 },
+      entradaValue: { type: 'currency', value: 61240 },
+      entradaVariation: { type: 'percent', value: 0.162 },
+      entradaAverage: { type: 'currency', value: 5120 },
+      saidaValue: { type: 'currency', value: 38450 },
+      saidaVariation: { type: 'percent', value: -0.041 },
+      saidaTop: { type: 'text', value: 'Campanhas, Operações' },
+      contasValue: { type: 'currency', value: 21200 },
+      contasDue: { type: 'text', value: '2 vencendo' },
+      contasNext: { type: 'text', value: 'Folha, Fornecedores' },
+    },
+    line: {
+      labels: monthlyLabels,
+      datasets: [
+        {
+          label: 'Entradas',
+          data: [32000, 33800, 35100, 36500, 37900, 39400, 41200, 42500, 43800, 45200, 48000, 61240],
+          borderColor: 'rgba(16, 185, 129, 1)',
+          backgroundColor: 'rgba(16, 185, 129, 0.2)',
+          tension: 0.45,
+          fill: true,
+        },
+      ],
+    },
+    donut: {
+      labels: ['Consultorias premium', 'Mentorias', 'Royalties', 'Produtos digitais'],
+      data: [22000, 13500, 15800, 9940],
+      colors: ['#10b981', '#22d3ee', '#6366f1', '#f472b6'],
+    },
+    events: [
+      { date: '2025-04-02', type: 'entrada', title: 'Consultoria XPTO', amount: 8200 },
+      { date: '2025-04-08', type: 'entrada', title: 'Licenças anuais', amount: 12400 },
+      { date: '2025-04-15', type: 'entrada', title: 'Mentoria executiva', amount: 5300 },
+      { date: '2025-04-22', type: 'entrada', title: 'Royalties plataforma', amount: 9100 },
+      { date: '2025-04-27', type: 'entrada', title: 'Investidor estratégico', amount: 13200 },
+    ],
+    timeline: [
+      { title: 'Contrato fechado', detail: 'Mentoria scale-up', type: 'entrada', amount: 6800, time: 'há 12 minutos' },
+      { title: 'Recorrência processada', detail: 'Produtos digitais', type: 'entrada', amount: 4200, time: 'há 48 minutos' },
+      { title: 'Entrada confirmada', detail: 'Investidor estratégico', type: 'entrada', amount: 13200, time: 'há 2 horas' },
+      { title: 'Previsão ajustada', detail: 'Projeção trimestral', type: 'entrada', amount: 0, time: 'há 5 horas' },
+    ],
+  },
+  saida: {
+    highlightCard: 'saidas',
+    titles: {
+      lineTitle: 'Saídas controladas',
+      lineSubtitle: 'Compromissos liquidados',
+      donutTitle: 'Saídas por centro de custo',
+      donutSubtitle: 'Visão do mês corrente',
+    },
+    cards: {
+      saldoValue: { type: 'currency', value: 172980.12 },
+      saldoVariation: { type: 'percent', value: 0.052 },
+      entradaValue: { type: 'currency', value: 61240 },
+      entradaVariation: { type: 'percent', value: 0.098 },
+      entradaAverage: { type: 'currency', value: 4580 },
+      saidaValue: { type: 'currency', value: 34220 },
+      saidaVariation: { type: 'percent', value: -0.068 },
+      saidaTop: { type: 'text', value: 'Operações, Marketing, Pessoas' },
+      contasValue: { type: 'currency', value: 19890 },
+      contasDue: { type: 'text', value: '1 vencendo' },
+      contasNext: { type: 'text', value: 'Infra, Jurídico, Tributos' },
+    },
+    line: {
+      labels: monthlyLabels,
+      datasets: [
+        {
+          label: 'Saídas',
+          data: [26800, 27900, 28800, 29640, 30500, 31420, 32200, 33100, 33820, 34220, 34980, 35200],
+          borderColor: 'rgba(248, 113, 113, 1)',
+          backgroundColor: 'rgba(248, 113, 113, 0.18)',
+          tension: 0.45,
+          fill: true,
+        },
+      ],
+    },
+    donut: {
+      labels: ['Operações', 'Marketing', 'Pessoas', 'Tecnologia'],
+      data: [11800, 8200, 7600, 5620],
+      colors: ['#f97316', '#fb7185', '#facc15', '#6366f1'],
+    },
+    events: [
+      { date: '2025-04-04', type: 'saida', title: 'Campanha de mídia', amount: 6200 },
+      { date: '2025-04-10', type: 'saida', title: 'Infraestrutura cloud', amount: 4100 },
+      { date: '2025-04-12', type: 'saida', title: 'Equipe de produto', amount: 5200 },
+      { date: '2025-04-18', type: 'saida', title: 'Treinamento time', amount: 2200 },
+      { date: '2025-04-24', type: 'saida', title: 'Serviços jurídicos', amount: 1800 },
+    ],
+    timeline: [
+      { title: 'Pagamento efetuado', detail: 'Infraestrutura cloud', type: 'saida', amount: -4100, time: 'há 18 minutos' },
+      { title: 'Equipe bonificada', detail: 'Programa de talentos', type: 'saida', amount: -5200, time: 'há 1 hora' },
+      { title: 'Campanha aprovada', detail: 'Marketing performance', type: 'saida', amount: -6200, time: 'há 3 horas' },
+      { title: 'Auditoria concluída', detail: 'Compliance mensal', type: 'saida', amount: 0, time: 'há 5 horas' },
+    ],
+  },
+  contas: {
+    highlightCard: 'contas',
+    titles: {
+      lineTitle: 'Contas programadas',
+      lineSubtitle: 'Previsão de pagamentos',
+      donutTitle: 'Status das contas',
+      donutSubtitle: 'Situação desta semana',
+    },
+    cards: {
+      saldoValue: { type: 'currency', value: 162300.55 },
+      saldoVariation: { type: 'percent', value: 0.037 },
+      entradaValue: { type: 'currency', value: 58900 },
+      entradaVariation: { type: 'percent', value: 0.074 },
+      entradaAverage: { type: 'currency', value: 4080 },
+      saidaValue: { type: 'currency', value: 31200 },
+      saidaVariation: { type: 'percent', value: -0.031 },
+      saidaTop: { type: 'text', value: 'Infra, Pessoas, Serviços' },
+      contasValue: { type: 'currency', value: 24230 },
+      contasDue: { type: 'text', value: '3 vencendo' },
+      contasNext: { type: 'text', value: 'Folha, ERP, Tributos' },
+    },
+    line: {
+      labels: monthlyLabels,
+      datasets: [
+        {
+          label: 'Contas previstas',
+          data: [18200, 19400, 20100, 21900, 22500, 23100, 24000, 24600, 25500, 26200, 23800, 24230],
+          borderColor: 'rgba(250, 204, 21, 1)',
+          backgroundColor: 'rgba(250, 204, 21, 0.18)',
+          tension: 0.4,
+          fill: true,
+        },
+      ],
+    },
+    donut: {
+      labels: ['Vencidas', 'Vencendo', 'Programadas', 'Provisionadas'],
+      data: [6400, 8200, 5200, 3430],
+      colors: ['#f87171', '#facc15', '#60a5fa', '#a855f7'],
+    },
+    events: [
+      { date: '2025-04-03', type: 'contas', title: 'Folha de pagamento', amount: 15800 },
+      { date: '2025-04-09', type: 'contas', title: 'Software ERP', amount: 3400 },
+      { date: '2025-04-17', type: 'contas', title: 'Energia elétrica', amount: 1870 },
+      { date: '2025-04-21', type: 'contas', title: 'Serviços contábeis', amount: 920 },
+      { date: '2025-04-26', type: 'contas', title: 'Impostos municipais', amount: 4600 },
+    ],
+    timeline: [
+      { title: 'Conta programada', detail: 'Serviços contábeis', type: 'contas', amount: -920, time: 'há 20 minutos' },
+      { title: 'Pagamento agendado', detail: 'Folha de pagamento', type: 'contas', amount: -15800, time: 'há 2 horas' },
+      { title: 'Alerta gerado', detail: 'Impostos municipais', type: 'contas', amount: -4600, time: 'há 4 horas' },
+      { title: 'Negociação concluída', detail: 'Software ERP', type: 'contas', amount: -3400, time: 'há 6 horas' },
+    ],
+  },
+};
+
+const quickLinks = document.querySelectorAll('.quick-link');
+const cards = document.querySelectorAll('.card');
+const chips = document.querySelectorAll('.chip');
+const lineChartTitle = document.getElementById('lineChartTitle');
+const lineChartSubtitle = document.getElementById('lineChartSubtitle');
+const donutChartTitle = document.getElementById('donutChartTitle');
+const donutChartSubtitle = document.getElementById('donutChartSubtitle');
+const calendarMonth = document.getElementById('calendarMonth');
+const calendarGrid = document.querySelector('.calendar-grid');
+const calendarDetails = document.getElementById('calendarDetails');
+const activityTimeline = document.getElementById('activityTimeline');
+const themeToggle = document.getElementById('themeToggle');
+
+let currentView = 'resumo';
+let currentRange = 12;
+let currentDate = new Date(financeData.resumo.events[0].date);
+
+const lineChart = new Chart(document.getElementById('lineChart'), {
+  type: 'line',
+  data: {
+    labels: [],
+    datasets: [],
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        labels: {
+          usePointStyle: true,
+        },
+      },
+      tooltip: {
+        callbacks: {
+          label: (ctx) => {
+            const value = ctx.parsed.y;
+            return `${ctx.dataset.label}: ${formatCurrency(value)}`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        grid: {
+          color: 'rgba(148, 163, 184, 0.08)',
+        },
+      },
+      y: {
+        grid: {
+          color: 'rgba(148, 163, 184, 0.08)',
+        },
+        ticks: {
+          callback: (value) => formatCurrency(value),
+        },
+      },
+    },
+  },
+});
+
+const donutChart = new Chart(document.getElementById('donutChart'), {
+  type: 'doughnut',
+  data: {
+    labels: [],
+    datasets: [
+      {
+        data: [],
+        backgroundColor: [],
+        borderWidth: 0,
+      },
+    ],
+  },
+  options: {
+    cutout: '70%',
+    plugins: {
+      legend: {
+        position: 'bottom',
+        labels: {
+          boxWidth: 12,
+          usePointStyle: true,
+        },
+      },
+      tooltip: {
+        callbacks: {
+          label: (ctx) => `${ctx.label}: ${formatCurrency(ctx.parsed)}`,
+        },
+      },
+    },
+  },
+});
+
+function applyRange(data, range) {
+  return data.slice(-range);
+}
+
+function updateCards(viewKey) {
+  const data = financeData[viewKey].cards;
+  Object.entries(data).forEach(([key, descriptor]) => {
+    const target = document.querySelector(`[data-field="${key}"]`);
+    if (!target) return;
+    let text = descriptor.value;
+    switch (descriptor.type) {
+      case 'currency':
+        text = formatCurrency(descriptor.value);
+        break;
+      case 'percent':
+        text = formatPercent(descriptor.value);
+        break;
+      default:
+        text = descriptor.value;
+    }
+    target.textContent = text;
+  });
+
+  cards.forEach((card) => {
+    const key = financeData[viewKey].highlightCard;
+    card.classList.toggle('focus', key && card.dataset.card === key);
+  });
+}
+
+function updateLineChart(viewKey) {
+  const { line } = financeData[viewKey];
+  const labels = applyRange(line.labels, currentRange);
+  const datasets = line.datasets.map((dataset) => ({
+    ...dataset,
+    data: applyRange(dataset.data, currentRange),
+  }));
+
+  lineChart.data.labels = labels;
+  lineChart.data.datasets = datasets;
+  lineChart.update();
+}
+
+function updateDonutChart(viewKey) {
+  const { donut } = financeData[viewKey];
+  donutChart.data.labels = donut.labels;
+  donutChart.data.datasets[0].data = donut.data;
+  donutChart.data.datasets[0].backgroundColor = donut.colors;
+  donutChart.update();
+}
+
+function renderTimeline(viewKey) {
+  const items = financeData[viewKey].timeline;
+  activityTimeline.innerHTML = '';
+  items.forEach((item) => {
+    const li = document.createElement('li');
+    li.classList.add('timeline-item');
+    const amountText =
+      item.amount === 0
+        ? '—'
+        : `${item.amount > 0 ? '+' : '-'}${formatCurrency(Math.abs(item.amount))}`;
+    li.innerHTML = `
+      <strong>${item.title}</strong>
+      <span class="meta">${item.detail} · ${item.time}</span>
+      <span class="amount ${item.type}">${amountText}</span>
+    `;
+    activityTimeline.appendChild(li);
+  });
+}
+
+function sameDay(a, b) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+function renderCalendar(viewKey) {
+  const events = financeData[viewKey].events;
+  const monthFormat = new Intl.DateTimeFormat('pt-BR', { month: 'long', year: 'numeric' });
+  calendarMonth.textContent = monthFormat
+    .format(currentDate)
+    .replace(/^./, (c) => c.toUpperCase());
+
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+  const start = new Date(year, month, 1);
+  const startOffset = (start.getDay() + 6) % 7; // Monday-first week
+  const totalDays = new Date(year, month + 1, 0).getDate();
+  const totalCells = Math.ceil((startOffset + totalDays) / 7) * 7;
+
+  calendarGrid.innerHTML = '';
+  let firstActiveCell = null;
+
+  for (let cellIndex = 0; cellIndex < totalCells; cellIndex += 1) {
+    const dayNumber = cellIndex - startOffset + 1;
+    const cellDate = new Date(year, month, dayNumber);
+    const isCurrentMonth = dayNumber > 0 && dayNumber <= totalDays;
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'calendar-cell';
+    button.setAttribute('role', 'gridcell');
+
+    if (!isCurrentMonth) {
+      button.classList.add('is-out');
+      button.innerHTML = '<span class="date">&nbsp;</span>';
+      calendarGrid.appendChild(button);
+      continue;
+    }
+
+    const eventsForDay = events.filter((event) => {
+      const eventDate = new Date(event.date);
+      return sameDay(eventDate, cellDate);
+    });
+
+    const net = eventsForDay.reduce((acc, event) => {
+      const direction = event.type === 'entrada' ? 1 : -1;
+      return acc + direction * event.amount;
+    }, 0);
+    const amountLabel = eventsForDay.length
+      ? `${net >= 0 ? '+' : '-'}${formatCurrency(Math.abs(net))}`
+      : '—';
+
+    button.innerHTML = `
+      <span class="date">${String(dayNumber).padStart(2, '0')}</span>
+      <span class="amount">${amountLabel}</span>
+    `;
+
+    const badges = document.createElement('div');
+    badges.className = 'badges';
+    const types = Array.from(new Set(eventsForDay.map((event) => event.type)));
+    types.forEach((type) => {
+      const dot = document.createElement('span');
+      dot.className = `dot ${type === 'contas' ? 'warning' : type === 'entrada' ? 'positive' : 'negative'}`;
+      badges.appendChild(dot);
+    });
+    if (types.length) {
+      button.appendChild(badges);
+    }
+
+    button.addEventListener('click', () => {
+      document.querySelectorAll('.calendar-cell.active').forEach((cell) => cell.classList.remove('active'));
+      button.classList.add('active');
+      renderCalendarDetails(eventsForDay, cellDate);
+    });
+
+    calendarGrid.appendChild(button);
+
+    if (!firstActiveCell && eventsForDay.length) {
+      firstActiveCell = { button, events: eventsForDay, date: cellDate };
+    }
+  }
+
+  if (firstActiveCell) {
+    firstActiveCell.button.classList.add('active');
+    renderCalendarDetails(firstActiveCell.events, firstActiveCell.date);
+  } else {
+    renderCalendarDetails([], currentDate);
+  }
+}
+
+function renderCalendarDetails(events, date) {
+  const dayFormat = new Intl.DateTimeFormat('pt-BR', { day: '2-digit', month: 'long' });
+  calendarDetails.innerHTML = '';
+
+  if (!events.length) {
+    const empty = document.createElement('li');
+    empty.textContent = `${dayFormat.format(date)} • Sem movimentações`;
+    calendarDetails.appendChild(empty);
+    return;
+  }
+
+  events
+    .sort((a, b) => b.amount - a.amount)
+    .forEach((event) => {
+      const item = document.createElement('li');
+      const badgeClass = event.type === 'contas' ? 'warning' : event.type === 'entrada' ? 'positive' : 'negative';
+      const amountText =
+        event.type === 'entrada'
+          ? `+${formatCurrency(event.amount)}`
+          : `-${formatCurrency(event.amount)}`;
+      const formattedDate = dayFormat
+        .format(new Date(event.date))
+        .replace(/^./, (c) => c.toUpperCase());
+      item.innerHTML = `
+        <span>${formattedDate} · ${event.title}</span>
+        <span class="amount ${badgeClass}">${amountText}</span>
+      `;
+      calendarDetails.appendChild(item);
+    });
+}
+
+function updateTitles(viewKey) {
+  const { titles } = financeData[viewKey];
+  lineChartTitle.textContent = titles.lineTitle;
+  lineChartSubtitle.textContent = titles.lineSubtitle;
+  donutChartTitle.textContent = titles.donutTitle;
+  donutChartSubtitle.textContent = titles.donutSubtitle;
+}
+
+function updateView(viewKey) {
+  currentView = viewKey;
+  updateTitles(viewKey);
+  updateCards(viewKey);
+  updateLineChart(viewKey);
+  updateDonutChart(viewKey);
+  renderTimeline(viewKey);
+  renderCalendar(viewKey);
+}
+
+quickLinks.forEach((link) => {
+  link.addEventListener('click', () => {
+    const view = link.dataset.view;
+    if (view === currentView) return;
+
+    quickLinks.forEach((btn) => btn.classList.remove('active'));
+    link.classList.add('active');
+    updateView(view);
+  });
+});
+
+chips.forEach((chip) => {
+  chip.addEventListener('click', () => {
+    const range = Number(chip.dataset.range);
+    if (range === currentRange) return;
+
+    chips.forEach((item) => item.classList.remove('active'));
+    chip.classList.add('active');
+    currentRange = range;
+    updateLineChart(currentView);
+  });
+});
+
+function shiftMonth(delta) {
+  currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth() + delta, 1);
+  renderCalendar(currentView);
+}
+
+document.getElementById('prevMonth').addEventListener('click', () => shiftMonth(-1));
+document.getElementById('nextMonth').addEventListener('click', () => shiftMonth(1));
+
+themeToggle.addEventListener('click', () => {
+  document.body.classList.toggle('light');
+  themeToggle.querySelector('.icon').textContent = document.body.classList.contains('light') ? '🌞' : '🌙';
+});
+
+updateView('resumo');

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,600 @@
+:root {
+  color-scheme: dark;
+  --bg: #080c18;
+  --bg-elevated: rgba(17, 24, 39, 0.75);
+  --bg-panel: rgba(21, 32, 53, 0.8);
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #f9fafb;
+  --text-soft: #9ca3af;
+  --accent: #7c3aed;
+  --accent-soft: rgba(124, 58, 237, 0.16);
+  --positive: #10b981;
+  --negative: #f97316;
+  --warning: #facc15;
+  --shadow: 0 40px 80px -32px rgba(15, 23, 42, 0.7);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, rgba(124, 58, 237, 0.2), transparent 55%),
+    radial-gradient(circle at top right, rgba(59, 130, 246, 0.12), transparent 45%), var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+  backdrop-filter: blur(12px);
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 40px 32px;
+  background: linear-gradient(160deg, rgba(24, 33, 54, 0.85), rgba(14, 22, 41, 0.95));
+  border-right: 1px solid var(--border);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.logo {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #7c3aed, #4f46e5);
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.brand strong {
+  font-size: 1.1rem;
+}
+
+.brand small {
+  color: var(--text-soft);
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar-nav a {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 16px;
+  text-decoration: none;
+  border-radius: 14px;
+  background: transparent;
+  color: inherit;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.sidebar-nav a:hover {
+  background: rgba(255, 255, 255, 0.05);
+  transform: translateX(6px);
+}
+
+.sidebar-nav a.active {
+  background: rgba(124, 58, 237, 0.12);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.btn-outline {
+  background: transparent;
+  border: 1px solid rgba(124, 58, 237, 0.45);
+  color: inherit;
+  padding: 12px 18px;
+  border-radius: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.3s ease, border 0.3s ease;
+}
+
+.btn-outline:hover {
+  transform: translateY(-2px);
+  border-color: rgba(124, 58, 237, 0.8);
+}
+
+.content {
+  padding: 40px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--text-soft);
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.btn-ghost {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: inherit;
+  padding: 10px 12px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.3s ease, border 0.3s ease;
+}
+
+.btn-ghost:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.profile-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  font-weight: 600;
+}
+
+.quick-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.quick-link {
+  border: none;
+  border-radius: 16px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  transition: transform 0.3s ease, background 0.3s ease, border 0.3s ease;
+  border: 1px solid transparent;
+}
+
+.quick-link .icon {
+  font-size: 1.2rem;
+}
+
+.quick-link:hover {
+  transform: translateY(-3px);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.quick-link.active {
+  background: rgba(124, 58, 237, 0.15);
+  border-color: rgba(124, 58, 237, 0.4);
+  box-shadow: 0 20px 40px -24px rgba(124, 58, 237, 0.9);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.card {
+  border-radius: 24px;
+  padding: 24px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 20px;
+}
+
+.card.focus {
+  border-color: rgba(124, 58, 237, 0.5);
+  box-shadow: 0 32px 64px -36px rgba(124, 58, 237, 0.8);
+  transform: translateY(-4px);
+}
+
+.card header,
+.card footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--text-soft);
+}
+
+.card .value {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.label {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.pill.positive {
+  background: rgba(16, 185, 129, 0.16);
+  color: #6ee7b7;
+}
+
+.pill.negative {
+  background: rgba(249, 115, 22, 0.16);
+  color: #fcd34d;
+}
+
+.pill.warning {
+  background: rgba(250, 204, 21, 0.16);
+  color: #fde68a;
+}
+
+.secondary {
+  color: var(--text-soft);
+}
+
+.grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.panel {
+  border-radius: 24px;
+  padding: 28px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 20px;
+}
+
+.panel header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.chip-group {
+  display: inline-flex;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 4px;
+}
+
+.chip {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.chip.active {
+  background: rgba(124, 58, 237, 0.2);
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 12px;
+  text-align: center;
+}
+
+.calendar-cell {
+  border-radius: 16px;
+  padding: 14px 10px;
+  display: grid;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid transparent;
+  transition: transform 0.3s ease, border 0.3s ease;
+  cursor: pointer;
+}
+
+.calendar-cell.is-out {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.calendar-cell:hover,
+.calendar-cell.active {
+  transform: translateY(-3px);
+  border-color: rgba(124, 58, 237, 0.4);
+}
+
+.calendar-cell .date {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.calendar-cell .amount {
+  font-size: 0.85rem;
+  color: var(--text-soft);
+}
+
+.calendar-cell .badges {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+}
+
+.dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.dot.positive {
+  background: var(--positive);
+}
+
+.dot.negative {
+  background: var(--negative);
+}
+
+.dot.warning {
+  background: var(--warning);
+}
+
+.calendar-legend {
+  display: flex;
+  gap: 16px;
+  color: var(--text-soft);
+  font-size: 0.85rem;
+}
+
+.calendar-details {
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.calendar-details ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.calendar-details li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}
+
+.calendar-details .amount {
+  font-weight: 600;
+}
+
+.calendar-details .amount.positive {
+  color: var(--positive);
+}
+
+.calendar-details .amount.negative {
+  color: #fca5a5;
+}
+
+.calendar-details .amount.warning {
+  color: var(--warning);
+}
+
+.activity .timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px;
+  align-items: center;
+}
+
+.timeline-item::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 6px rgba(124, 58, 237, 0.18);
+}
+
+.timeline-item strong {
+  font-weight: 600;
+}
+
+.timeline-item span.meta {
+  color: var(--text-soft);
+  font-size: 0.85rem;
+}
+
+.timeline-item .amount {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.timeline-item .amount.entrada {
+  color: var(--positive);
+}
+
+.timeline-item .amount.saida,
+.timeline-item .amount.contas {
+  color: #fda4af;
+}
+
+body.light {
+  color-scheme: light;
+  --bg: #eef2ff;
+  --bg-panel: rgba(255, 255, 255, 0.9);
+  --border: rgba(15, 23, 42, 0.08);
+  --text: #0f172a;
+  --text-soft: #475569;
+  --accent: #4f46e5;
+  --accent-soft: rgba(79, 70, 229, 0.16);
+  --positive: #059669;
+  --negative: #f97316;
+  --warning: #facc15;
+  --shadow: 0 30px 60px -28px rgba(30, 41, 59, 0.22);
+  background: radial-gradient(circle at top left, rgba(79, 70, 229, 0.15), transparent 55%),
+    radial-gradient(circle at top right, rgba(14, 165, 233, 0.12), transparent 45%), var(--bg);
+}
+
+body.light .sidebar {
+  background: linear-gradient(150deg, rgba(237, 233, 254, 0.92), rgba(224, 231, 255, 0.95));
+  border-right: 1px solid var(--border);
+}
+
+body.light .btn-ghost {
+  background: rgba(15, 23, 42, 0.04);
+  border-color: rgba(15, 23, 42, 0.08);
+}
+
+body.light .profile-card {
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+}
+
+body.light .quick-link {
+  background: rgba(255, 255, 255, 0.88);
+}
+
+body.light .quick-link.active {
+  background: rgba(79, 70, 229, 0.2);
+  box-shadow: 0 20px 40px -24px rgba(79, 70, 229, 0.4);
+}
+
+body.light .card,
+body.light .panel {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+@media (max-width: 1180px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+  }
+
+  .content {
+    padding: 32px;
+  }
+}
+
+@media (max-width: 900px) {
+  .sidebar {
+    display: none;
+  }
+
+  .content {
+    padding: 24px;
+  }
+
+  .cards {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .top-bar {
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
+  }
+
+  .quick-links {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone Finace David dashboard website with sidebar navigation, quick filters, KPIs, charts, calendar, and activity timeline
- style the experience with a premium dark aesthetic, responsive layout, and optional light theme toggle
- script interactive behaviors for dataset switching, Chart.js visualisations, calendar filtering, and theme management

## Testing
- python3 -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_b_68e5a34fbd84832e874c10c947ef28a9