### PR TITLE
Refine dashboard into rich Windows-style experience

### DIFF
--- a/src/FinaceDavid.App/Services/Models/CalendarDay.cs
+++ b/src/FinaceDavid.App/Services/Models/CalendarDay.cs
@@ -1,3 +1,27 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace FinaceDavid.Services.Models;
 
-public record CalendarDay(DateTime Date, decimal Total, bool HasTransactions, bool IsCurrentMonth);
+public partial class CalendarDay : ObservableObject
+{
+    public CalendarDay(DateTime date, decimal total, bool hasTransactions, bool isCurrentMonth)
+    {
+        Date = date;
+        Total = total;
+        HasTransactions = hasTransactions;
+        IsCurrentMonth = isCurrentMonth;
+    }
+
+    public DateTime Date { get; }
+
+    public decimal Total { get; }
+
+    public bool HasTransactions { get; }
+
+    public bool IsCurrentMonth { get; }
+
+    public bool IsToday => Date.Date == DateTime.Today;
+
+    [ObservableProperty]
+    private bool isSelected;
+}

--- a/src/FinaceDavid.App/Services/Models/CategoryBreakdown.cs
+++ b/src/FinaceDavid.App/Services/Models/CategoryBreakdown.cs
@@ -1,0 +1,3 @@
+namespace FinaceDavid.Services.Models;
+
+public record CategoryBreakdown(string Categoria, decimal Total);

--- a/src/FinaceDavid.App/ViewModels/CalendarViewModel.cs
+++ b/src/FinaceDavid.App/ViewModels/CalendarViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using FinaceDavid.Services;
@@ -34,6 +35,7 @@ public partial class CalendarViewModel : ViewModelBase
             {
                 Days.Add(day);
             }
+            HighlightDate(_filterStateService.CurrentRange.Start.Date);
         }
         finally
         {
@@ -63,6 +65,19 @@ public partial class CalendarViewModel : ViewModelBase
             return;
         }
 
-        _filterStateService.SetPeriod(PeriodFilter.Intervalo, day.Value.Date, day.Value.Date);
+        _filterStateService.SetPeriod(PeriodFilter.Intervalo, day.Date, day.Date);
+        HighlightDate(day.Date);
+    }
+
+    private void HighlightDate(DateTime date)
+    {
+        var selected = Days.FirstOrDefault(d => d.Date.Date == date)
+                       ?? Days.FirstOrDefault(d => d.IsCurrentMonth && d.Date.Day == 1)
+                       ?? Days.FirstOrDefault(d => d.IsCurrentMonth);
+
+        foreach (var item in Days)
+        {
+            item.IsSelected = ReferenceEquals(item, selected);
+        }
     }
 }

--- a/src/FinaceDavid.App/ViewModels/HomeViewModel.cs
+++ b/src/FinaceDavid.App/ViewModels/HomeViewModel.cs
@@ -1,4 +1,6 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using FinaceDavid.Domain.Entities;
@@ -14,6 +16,8 @@ public partial class HomeViewModel : ViewModelBase
     private readonly IReportService _reportService;
     private readonly IThemeService _themeService;
     private readonly IFilterStateService _filterStateService;
+    private readonly ICalendarService _calendarService;
+    private readonly CultureInfo _culture = CultureInfo.GetCultureInfo("pt-BR");
 
     [ObservableProperty]
     private decimal saldo;
@@ -24,20 +28,52 @@ public partial class HomeViewModel : ViewModelBase
     [ObservableProperty]
     private decimal totalSaidas;
 
+    [ObservableProperty]
+    private string periodDescription = string.Empty;
+
+    [ObservableProperty]
+    private string resumoNarrativa = string.Empty;
+
+    [ObservableProperty]
+    private bool isResumoExpanded = true;
+
+    [ObservableProperty]
+    private DateTime calendarMonth = new(DateTime.Today.Year, DateTime.Today.Month, 1);
+
+    [ObservableProperty]
+    private CalendarDay? highlightedDay;
+
+    [ObservableProperty]
+    private string highlightedDayLabel = "Selecione uma data";
+
+    [ObservableProperty]
+    private decimal highlightedDayEntradas;
+
+    [ObservableProperty]
+    private decimal highlightedDaySaidas;
+
+    public decimal HighlightedDaySaldo => HighlightedDayEntradas - HighlightedDaySaidas;
+
     public ObservableCollection<ChartSlice> DonutSlices { get; } = new();
     public ObservableCollection<TrendPoint> TrendPoints { get; } = new();
     public ObservableCollection<Transaction> RecentTransactions { get; } = new();
+    public ObservableCollection<CalendarDay> CalendarDays { get; } = new();
+    public ObservableCollection<DailySummary> PeriodSummaries { get; } = new();
+    public ObservableCollection<Transaction> DailyTransactions { get; } = new();
+    public ObservableCollection<CategoryBreakdown> CategoryHighlights { get; } = new();
 
     public HomeViewModel(
         ITransactionService transactionService,
         IReportService reportService,
         IThemeService themeService,
-        IFilterStateService filterStateService)
+        IFilterStateService filterStateService,
+        ICalendarService calendarService)
     {
         _transactionService = transactionService;
         _reportService = reportService;
         _themeService = themeService;
         _filterStateService = filterStateService;
+        _calendarService = calendarService;
         Title = "Dashboard";
         _filterStateService.FilterChanged += (_, _) => _ = LoadAsync();
     }
@@ -52,29 +88,40 @@ public partial class HomeViewModel : ViewModelBase
         IsBusy = true;
         try
         {
-            var filter = new TransactionFilter(_filterStateService.CurrentRange);
-            TotalEntradas = await _transactionService.GetTotalAsync(TransactionType.Entrada, filter);
-            TotalSaidas = await _transactionService.GetTotalAsync(TransactionType.Saida, filter);
+            var range = _filterStateService.CurrentRange;
+            var filter = new TransactionFilter(range);
+
+            PeriodDescription = BuildPeriodDescription(_filterStateService.CurrentPeriod, range);
+
+            var entradasTask = _transactionService.GetTotalAsync(TransactionType.Entrada, filter);
+            var saidasTask = _transactionService.GetTotalAsync(TransactionType.Saida, filter);
+            var transactionsTask = _transactionService.GetTransactionsAsync(filter);
+            var donutTask = _reportService.BuildDonutAsync(filter);
+            var trendTask = _reportService.BuildTrendAsync(filter);
+
+            TotalEntradas = await entradasTask;
+            TotalSaidas = await saidasTask;
             Saldo = TotalEntradas - TotalSaidas;
 
-            DonutSlices.Clear();
-            foreach (var slice in await _reportService.BuildDonutAsync(filter))
-            {
-                DonutSlices.Add(slice);
-            }
+            SyncCollection(DonutSlices, await donutTask);
+            SyncCollection(TrendPoints, await trendTask);
 
-            TrendPoints.Clear();
-            foreach (var point in await _reportService.BuildTrendAsync(filter))
-            {
-                TrendPoints.Add(point);
-            }
+            var transactions = await transactionsTask;
+            UpdateRecentTransactions(transactions);
+            UpdateCategoryHighlights(transactions);
 
-            RecentTransactions.Clear();
-            var transactions = await _transactionService.GetTransactionsAsync(filter);
-            foreach (var item in transactions.Take(10))
-            {
-                RecentTransactions.Add(item);
-            }
+            var summaries = transactions
+                .GroupBy(t => t.Data.Date)
+                .Select(g => new DailySummary(
+                    g.Key,
+                    g.Where(t => t.Type == TransactionType.Entrada).Sum(t => t.Valor),
+                    g.Where(t => t.Type == TransactionType.Saida).Sum(t => t.Valor)))
+                .OrderBy(s => s.Date)
+                .ToList();
+            UpdatePeriodSummaries(summaries);
+
+            CalendarMonth = new DateTime(range.Start.Year, range.Start.Month, 1);
+            await RefreshCalendarAsync(range.Start);
         }
         finally
         {
@@ -113,6 +160,161 @@ public partial class HomeViewModel : ViewModelBase
             case "Tema":
                 await ToggleThemeAsync();
                 break;
+            case "Resumo":
+                IsResumoExpanded = !IsResumoExpanded;
+                break;
         }
     }
+
+    [RelayCommand]
+    private async Task NextCalendarMonthAsync()
+    {
+        CalendarMonth = CalendarMonth.AddMonths(1);
+        await RefreshCalendarAsync();
+    }
+
+    [RelayCommand]
+    private async Task PreviousCalendarMonthAsync()
+    {
+        CalendarMonth = CalendarMonth.AddMonths(-1);
+        await RefreshCalendarAsync();
+    }
+
+    [RelayCommand]
+    private async Task SelectCalendarDayAsync(CalendarDay? day)
+    {
+        if (day is null)
+        {
+            return;
+        }
+
+        CalendarMonth = new DateTime(day.Date.Year, day.Date.Month, 1);
+        HighlightedDay = day;
+        await UpdateHighlightedDayAsync(day);
+        _filterStateService.SetPeriod(PeriodFilter.Intervalo, day.Date, day.Date);
+    }
+
+    private async Task RefreshCalendarAsync(DateTime? highlightDate = null)
+    {
+        var days = await _calendarService.BuildMonthAsync(CalendarMonth);
+        SyncCollection(CalendarDays, days);
+
+        var selected = highlightDate.HasValue
+            ? CalendarDays.FirstOrDefault(d => d.Date.Date == highlightDate.Value.Date)
+            : CalendarDays.FirstOrDefault(d => d.IsCurrentMonth && d.IsToday)
+              ?? CalendarDays.FirstOrDefault(d => d.IsCurrentMonth)
+              ?? CalendarDays.FirstOrDefault();
+
+        HighlightedDay = selected;
+
+        if (selected is not null)
+        {
+            await UpdateHighlightedDayAsync(selected);
+        }
+        else
+        {
+            DailyTransactions.Clear();
+            HighlightedDayEntradas = 0;
+            HighlightedDaySaidas = 0;
+            HighlightedDayLabel = "Selecione uma data";
+        }
+    }
+
+    private async Task UpdateHighlightedDayAsync(CalendarDay day)
+    {
+        UpdateCalendarSelection(day);
+        HighlightedDayLabel = _culture.TextInfo.ToTitleCase(day.Date.ToString("dddd, dd 'de' MMMM", _culture));
+
+        var range = new DateRange(day.Date, day.Date.AddDays(1).AddTicks(-1));
+        var filter = new TransactionFilter(range);
+        var transactions = await _transactionService.GetTransactionsAsync(filter);
+
+        DailyTransactions.Clear();
+        foreach (var transaction in transactions.OrderByDescending(t => t.Data))
+        {
+            DailyTransactions.Add(transaction);
+        }
+
+        HighlightedDayEntradas = transactions.Where(t => t.Type == TransactionType.Entrada).Sum(t => t.Valor);
+        HighlightedDaySaidas = transactions.Where(t => t.Type == TransactionType.Saida).Sum(t => t.Valor);
+    }
+
+    private void UpdateRecentTransactions(IEnumerable<Transaction> transactions)
+    {
+        RecentTransactions.Clear();
+        foreach (var item in transactions.OrderByDescending(t => t.Data).Take(8))
+        {
+            RecentTransactions.Add(item);
+        }
+    }
+
+    private void UpdateCategoryHighlights(IEnumerable<Transaction> transactions)
+    {
+        var highlights = transactions
+            .Where(t => t.Type == TransactionType.Saida)
+            .GroupBy(t => string.IsNullOrWhiteSpace(t.Categoria) ? "Outros" : t.Categoria)
+            .Select(g => new CategoryBreakdown(g.Key, g.Sum(t => t.Valor)))
+            .OrderByDescending(c => c.Total)
+            .Take(4)
+            .ToList();
+
+        SyncCollection(CategoryHighlights, highlights);
+    }
+
+    private void UpdatePeriodSummaries(IReadOnlyList<DailySummary> summaries)
+    {
+        var ordered = summaries
+            .OrderByDescending(s => s.Date)
+            .Take(7)
+            .OrderBy(s => s.Date)
+            .ToList();
+
+        SyncCollection(PeriodSummaries, ordered);
+
+        var totalEntrada = summaries.Sum(s => s.TotalEntrada);
+        var totalSaida = summaries.Sum(s => s.TotalSaida);
+        var saldoPeriodo = totalEntrada - totalSaida;
+
+        ResumoNarrativa = summaries.Any()
+            ? $"No período você recebeu {totalEntrada.ToString("C2", _culture)} e pagou {totalSaida.ToString("C2", _culture)}, fechando com {saldoPeriodo.ToString("C2", _culture)}."
+            : "Nenhuma movimentação registrada no período selecionado.";
+    }
+
+    private void UpdateCalendarSelection(CalendarDay? selected)
+    {
+        foreach (var day in CalendarDays)
+        {
+            day.IsSelected = selected is not null && day.Date.Date == selected.Date.Date;
+        }
+    }
+
+    private string BuildPeriodDescription(PeriodFilter period, DateRange range)
+    {
+        var start = range.Start.Date;
+        var end = range.End.Date;
+
+        return period switch
+        {
+            PeriodFilter.Hoje => "Hoje",
+            PeriodFilter.SeteDias => "Últimos 7 dias",
+            PeriodFilter.MesAtual => _culture.TextInfo.ToTitleCase(start.ToString("MMMM yyyy", _culture)),
+            PeriodFilter.Intervalo => $"{start:dd MMM} — {end:dd MMM}",
+            _ => $"{start:dd/MM} - {end:dd/MM}"
+        };
+    }
+
+    private static void SyncCollection<T>(ObservableCollection<T> target, IEnumerable<T> source)
+    {
+        target.Clear();
+        foreach (var item in source)
+        {
+            target.Add(item);
+        }
+    }
+
+    partial void OnHighlightedDayEntradasChanged(decimal value) => OnPropertyChanged(nameof(HighlightedDaySaldo));
+
+    partial void OnHighlightedDaySaidasChanged(decimal value) => OnPropertyChanged(nameof(HighlightedDaySaldo));
+
+    partial void OnHighlightedDayChanged(CalendarDay? value) => UpdateCalendarSelection(value);
 }

--- a/src/FinaceDavid.App/Views/CalendarPage.xaml
+++ b/src/FinaceDavid.App/Views/CalendarPage.xaml
@@ -19,10 +19,20 @@
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:CalendarDay">
-                    <Border StrokeShape="RoundRectangle 12" BackgroundColor="{Binding HasTransactions, Converter={StaticResource BoolToColorConverter}, ConverterParameter='has'}" Padding="6" Margin="4">
+                    <Border StrokeShape="RoundRectangle 12" Padding="6" Margin="4" Stroke="{DynamicResource CardBorderColor}">
+                        <Border.Triggers>
+                            <DataTrigger TargetType="Border" Binding="{Binding IsSelected}" Value="True">
+                                <Setter Property="BackgroundColor" Value="{DynamicResource AccentColor}" />
+                                <Setter Property="Stroke" Value="{DynamicResource AccentColor}" />
+                            </DataTrigger>
+                            <DataTrigger TargetType="Border" Binding="{Binding IsCurrentMonth}" Value="False">
+                                <Setter Property="Opacity" Value="0.4" />
+                            </DataTrigger>
+                        </Border.Triggers>
                         <VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center" Spacing="4">
                             <Label Text="{Binding Date, StringFormat='{0:dd}'}" HorizontalOptions="Center" TextColor="{DynamicResource PrimaryTextColor}" />
                             <Label Text="{Binding Total, StringFormat='{0:C0}'}" FontSize="10" TextColor="{DynamicResource SecondaryTextColor}" HorizontalOptions="Center" />
+                            <BoxView WidthRequest="6" HeightRequest="6" CornerRadius="3" Color="{DynamicResource SuccessColor}" IsVisible="{Binding HasTransactions}" HorizontalOptions="Center" />
                         </VerticalStackLayout>
                         <Border.GestureRecognizers>
                             <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:CalendarViewModel}}, Path=SelectDayCommand}" CommandParameter="{Binding .}" />

--- a/src/FinaceDavid.App/Views/HomePage.xaml
+++ b/src/FinaceDavid.App/Views/HomePage.xaml
@@ -5,86 +5,314 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:viewmodels="clr-namespace:FinaceDavid.ViewModels"
     xmlns:domain="clr-namespace:FinaceDavid.Domain.Entities"
+    xmlns:models="clr-namespace:FinaceDavid.Services.Models"
     BackgroundColor="{DynamicResource SurfaceColor}"
     x:DataType="viewmodels:HomeViewModel">
     <ScrollView>
-        <VerticalStackLayout Padding="24" Spacing="24">
-            <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto">
-                <VerticalStackLayout>
-                    <Label Text="Bem-vindo" FontSize="18" TextColor="{DynamicResource SecondaryTextColor}" />
-                    <Label Text="Saldo atual" FontSize="14" TextColor="{DynamicResource SecondaryTextColor}" />
-                    <Label Text="{Binding Saldo, StringFormat='R$ {0:N2}'}" FontSize="32" FontAttributes="Bold" TextColor="{DynamicResource AccentColor}" />
-                </VerticalStackLayout>
-                <Button
-                    Grid.Column="1"
-                    Text="Trocar tema"
-                    Command="{Binding ToggleThemeCommand}"
-                    BackgroundColor="{DynamicResource CardBackgroundColor}"
-                    TextColor="{DynamicResource PrimaryTextColor}"
-                    CornerRadius="12"
-                    HeightRequest="40" />
-            </Grid>
-            <Grid ColumnDefinitions="*,*" ColumnSpacing="16">
-                <Border Stroke="{DynamicResource CardBorderColor}" BackgroundColor="{DynamicResource CardBackgroundColor}" StrokeShape="RoundRectangle 18" Padding="16">
-                    <VerticalStackLayout>
-                        <Label Text="Entradas" TextColor="{DynamicResource SecondaryTextColor}" />
-                        <Label Text="{Binding TotalEntradas, StringFormat='R$ {0:N2}'}" FontSize="20" FontAttributes="Bold" TextColor="{DynamicResource SuccessColor}" />
+        <Grid
+            x:Name="LayoutRoot"
+            Padding="32"
+            RowSpacing="24"
+            ColumnSpacing="24">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition x:Name="SideColumn" Width="*" />
+            </Grid.ColumnDefinitions>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="Expanded">
+                        <VisualState.StateTriggers>
+                            <AdaptiveTrigger MinWindowWidth="1024" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter TargetName="SideColumn" Property="ColumnDefinition.Width" Value="380" />
+                            <Setter TargetName="MainPanel" Property="Grid.ColumnSpan" Value="1" />
+                            <Setter TargetName="SidePanel" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="SidePanel" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="SidePanel" Property="Grid.RowSpan" Value="2" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+
+            <VerticalStackLayout x:Name="MainPanel" Grid.ColumnSpan="2" Spacing="24">
+                <Grid ColumnDefinitions="*,Auto">
+                    <VerticalStackLayout Spacing="4">
+                        <Label Text="Finace David" FontSize="28" FontAttributes="Bold" TextColor="{DynamicResource PrimaryTextColor}" />
+                        <Label Text="Controle premium das suas finanças" TextColor="{DynamicResource SecondaryTextColor}" />
+                        <Label
+                            Text="{Binding PeriodDescription, StringFormat='Período ativo: {0}'}"
+                            FontSize="14"
+                            TextColor="{DynamicResource SecondaryTextColor}" />
                     </VerticalStackLayout>
-                </Border>
-                <Border Stroke="{DynamicResource CardBorderColor}" BackgroundColor="{DynamicResource CardBackgroundColor}" StrokeShape="RoundRectangle 18" Padding="16">
-                    <VerticalStackLayout>
-                        <Label Text="Saídas" TextColor="{DynamicResource SecondaryTextColor}" />
-                        <Label Text="{Binding TotalSaidas, StringFormat='R$ {0:N2}'}" FontSize="20" FontAttributes="Bold" TextColor="{DynamicResource DangerColor}" />
-                    </VerticalStackLayout>
-                </Border>
-            </Grid>
-            <HorizontalStackLayout Spacing="12" HorizontalOptions="Center" FlowDirection="LeftToRight">
-                <Button Text="Entradas" Command="{Binding OpenSectionCommand}" CommandParameter="Entradas" Style="{StaticResource ActionButtonStyle}" />
-                <Button Text="Saídas" Command="{Binding OpenSectionCommand}" CommandParameter="Saídas" Style="{StaticResource ActionButtonStyle}" />
-                <Button Text="Contas" Command="{Binding OpenSectionCommand}" CommandParameter="Contas" Style="{StaticResource ActionButtonStyle}" />
-                <Button Text="Tema" Command="{Binding OpenSectionCommand}" CommandParameter="Tema" Style="{StaticResource ActionButtonStyle}" />
-            </HorizontalStackLayout>
-            <HorizontalStackLayout Spacing="8" HorizontalOptions="Center">
-                <Button Text="Hoje" Command="{Binding SetPeriodCommand}" CommandParameter="Hoje" Style="{StaticResource FilterChipStyle}" />
-                <Button Text="7 dias" Command="{Binding SetPeriodCommand}" CommandParameter="SeteDias" Style="{StaticResource FilterChipStyle}" />
-                <Button Text="Mês" Command="{Binding SetPeriodCommand}" CommandParameter="MesAtual" Style="{StaticResource FilterChipStyle}" />
-            </HorizontalStackLayout>
-            <Grid ColumnDefinitions="*,*" ColumnSpacing="16" RowDefinitions="Auto">
-                <Border Grid.Column="0" StrokeShape="RoundRectangle 24" BackgroundColor="{DynamicResource CardBackgroundColor}" Padding="16">
+                    <Button
+                        Grid.Column="1"
+                        Text="Alternar tema"
+                        Command="{Binding ToggleThemeCommand}"
+                        Style="{StaticResource ActionButtonStyle}" />
+                </Grid>
+
+                <Grid ColumnDefinitions="*,*,*" ColumnSpacing="16">
+                    <Border StrokeShape="RoundRectangle 24" Padding="20">
+                        <VerticalStackLayout Spacing="8">
+                            <Label Text="Saldo consolidado" TextColor="{DynamicResource SecondaryTextColor}" />
+                            <Label
+                                Text="{Binding Saldo, StringFormat='R$ {0:N2}'}"
+                                FontSize="26"
+                                FontAttributes="Bold"
+                                TextColor="{DynamicResource AccentColor}" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border StrokeShape="RoundRectangle 24" Padding="20">
+                        <VerticalStackLayout Spacing="8">
+                            <Label Text="Entradas" TextColor="{DynamicResource SecondaryTextColor}" />
+                            <Label
+                                Text="{Binding TotalEntradas, StringFormat='R$ {0:N2}'}"
+                                FontSize="24"
+                                FontAttributes="Bold"
+                                TextColor="{DynamicResource SuccessColor}" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border StrokeShape="RoundRectangle 24" Padding="20">
+                        <VerticalStackLayout Spacing="8">
+                            <Label Text="Saídas" TextColor="{DynamicResource SecondaryTextColor}" />
+                            <Label
+                                Text="{Binding TotalSaidas, StringFormat='R$ {0:N2}'}"
+                                FontSize="24"
+                                FontAttributes="Bold"
+                                TextColor="{DynamicResource DangerColor}" />
+                        </VerticalStackLayout>
+                    </Border>
+                </Grid>
+
+                <FlexLayout Direction="Row" Wrap="Wrap" AlignItems="Center" JustifyContent="Start" Margin="0,8,0,0">
+                    <Button Margin="0,0,12,12" Text="Entradas" Command="{Binding OpenSectionCommand}" CommandParameter="Entradas" Style="{StaticResource ActionButtonStyle}" />
+                    <Button Margin="0,0,12,12" Text="Saídas" Command="{Binding OpenSectionCommand}" CommandParameter="Saídas" Style="{StaticResource ActionButtonStyle}" />
+                    <Button Margin="0,0,12,12" Text="Contas a pagar" Command="{Binding OpenSectionCommand}" CommandParameter="Contas" Style="{StaticResource ActionButtonStyle}" />
+                    <Button Margin="0,0,12,12" Text="Resumo" Command="{Binding OpenSectionCommand}" CommandParameter="Resumo" Style="{StaticResource ActionButtonStyle}">
+                        <Button.Triggers>
+                            <DataTrigger TargetType="Button" Binding="{Binding IsResumoExpanded}" Value="True">
+                                <Setter Property="BackgroundColor" Value="{DynamicResource AccentColor}" />
+                                <Setter Property="TextColor" Value="White" />
+                            </DataTrigger>
+                        </Button.Triggers>
+                    </Button>
+                    <Button Margin="0,0,12,12" Text="Tema" Command="{Binding OpenSectionCommand}" CommandParameter="Tema" Style="{StaticResource ActionButtonStyle}" />
+                </FlexLayout>
+
+                <Border StrokeShape="RoundRectangle 24" Padding="20">
                     <VerticalStackLayout Spacing="12">
-                        <Label Text="Distribuição" TextColor="{DynamicResource SecondaryTextColor}" />
-                        <GraphicsView x:Name="DonutView" HeightRequest="220" />
+                        <Grid ColumnDefinitions="Auto,*">
+                            <Label Text="Janela de análise" FontAttributes="Bold" TextColor="{DynamicResource PrimaryTextColor}" />
+                            <Label
+                                Grid.Column="1"
+                                HorizontalOptions="End"
+                                Text="{Binding PeriodDescription}"
+                                TextColor="{DynamicResource SecondaryTextColor}" />
+                        </Grid>
+                        <HorizontalStackLayout Spacing="12">
+                            <Button Text="Hoje" Command="{Binding SetPeriodCommand}" CommandParameter="Hoje" Style="{StaticResource FilterChipStyle}" />
+                            <Button Text="7 dias" Command="{Binding SetPeriodCommand}" CommandParameter="SeteDias" Style="{StaticResource FilterChipStyle}" />
+                            <Button Text="Mês" Command="{Binding SetPeriodCommand}" CommandParameter="MesAtual" Style="{StaticResource FilterChipStyle}" />
+                        </HorizontalStackLayout>
                     </VerticalStackLayout>
                 </Border>
-                <Border Grid.Column="1" StrokeShape="RoundRectangle 24" BackgroundColor="{DynamicResource CardBackgroundColor}" Padding="16">
-                    <VerticalStackLayout Spacing="12">
-                        <Label Text="Evolução" TextColor="{DynamicResource SecondaryTextColor}" />
-                        <GraphicsView x:Name="TrendView" HeightRequest="220" />
+
+                <Grid ColumnDefinitions="*,*" ColumnSpacing="16">
+                    <Border StrokeShape="RoundRectangle 24" Padding="20">
+                        <VerticalStackLayout Spacing="12">
+                            <Label Text="Distribuição de fluxos" TextColor="{DynamicResource SecondaryTextColor}" />
+                            <GraphicsView x:Name="DonutView" HeightRequest="220" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border StrokeShape="RoundRectangle 24" Padding="20">
+                        <VerticalStackLayout Spacing="12">
+                            <Label Text="Evolução temporal" TextColor="{DynamicResource SecondaryTextColor}" />
+                            <GraphicsView x:Name="TrendView" HeightRequest="220" />
+                        </VerticalStackLayout>
+                    </Border>
+                </Grid>
+
+                <Border StrokeShape="RoundRectangle 24" Padding="24" IsVisible="{Binding IsResumoExpanded}">
+                    <VerticalStackLayout Spacing="16">
+                        <Label Text="Resumo inteligente" FontSize="20" FontAttributes="Bold" TextColor="{DynamicResource PrimaryTextColor}" />
+                        <Label Text="{Binding ResumoNarrativa}" TextColor="{DynamicResource SecondaryTextColor}" />
+                        <CollectionView ItemsSource="{Binding PeriodSummaries}" SelectionMode="None">
+                            <CollectionView.EmptyView>
+                                <Label Text="Sem histórico para o período." TextColor="{DynamicResource SecondaryTextColor}" HorizontalOptions="Center" />
+                            </CollectionView.EmptyView>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="models:DailySummary">
+                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto" ColumnSpacing="12" Padding="0,4">
+                                        <Label Text="{Binding Date, StringFormat='{0:dd MMM}'}" TextColor="{DynamicResource PrimaryTextColor}" />
+                                        <Border Grid.Column="1" BackgroundColor="{DynamicResource CardBorderColor}" StrokeShape="RoundRectangle 8" Padding="6,2">
+                                            <Label Text="{Binding Date, StringFormat='{0:dddd}'}" TextColor="{DynamicResource SecondaryTextColor}" FontSize="12" TextTransform="Capitalize" />
+                                        </Border>
+                                        <Label
+                                            Grid.Column="2"
+                                            Text="{Binding TotalEntrada, StringFormat='+{0:C0}'}"
+                                            TextColor="{DynamicResource SuccessColor}"
+                                            HorizontalTextAlignment="End" />
+                                        <Label
+                                            Grid.Column="3"
+                                            Text="{Binding TotalSaida, StringFormat='-{0:C0}'}"
+                                            TextColor="{DynamicResource DangerColor}"
+                                            HorizontalTextAlignment="End" />
+                                    </Grid>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                        <CollectionView ItemsSource="{Binding CategoryHighlights}" SelectionMode="None">
+                            <CollectionView.ItemsLayout>
+                                <LinearItemsLayout Orientation="Horizontal" ItemSpacing="12" />
+                            </CollectionView.ItemsLayout>
+                            <CollectionView.EmptyView>
+                                <Label Text="Categorias aguardando lançamentos." TextColor="{DynamicResource SecondaryTextColor}" />
+                            </CollectionView.EmptyView>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="models:CategoryBreakdown">
+                                    <Border StrokeShape="RoundRectangle 16" Padding="16" BackgroundColor="{DynamicResource CardBorderColor}">
+                                        <VerticalStackLayout Spacing="4">
+                                            <Label Text="{Binding Categoria}" FontAttributes="Bold" TextColor="{DynamicResource PrimaryTextColor}" />
+                                            <Label Text="{Binding Total, StringFormat='R$ {0:N2}'}" TextColor="{DynamicResource SecondaryTextColor}" />
+                                        </VerticalStackLayout>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
                     </VerticalStackLayout>
                 </Border>
-            </Grid>
-            <Label Text="Transações recentes" FontSize="18" TextColor="{DynamicResource PrimaryTextColor}" />
-            <CollectionView ItemsSource="{Binding RecentTransactions}" SelectionMode="None">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="domain:Transaction" xmlns:domain="clr-namespace:FinaceDavid.Domain.Entities">
-                        <Border StrokeShape="RoundRectangle 16" BackgroundColor="{DynamicResource CardBackgroundColor}" Padding="16" Margin="0,0,0,12">
-                            <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto">
-                                <Label Text="{Binding Descricao}" FontAttributes="Bold" TextColor="{DynamicResource PrimaryTextColor}" />
-                                <Label Grid.Row="1" Text="{Binding Categoria}" TextColor="{DynamicResource SecondaryTextColor}" />
-                                <Label
-                                    Grid.Column="1"
-                                    Text="{Binding Valor, StringFormat='R$ {0:N2}'}"
-                                    TextColor="{DynamicResource PrimaryTextColor}" />
-                                <Label
-                                    Grid.Column="1"
-                                    Grid.Row="1"
-                                    Text="{Binding Data, StringFormat='{0:dd/MM}'}"
-                                    TextColor="{DynamicResource SecondaryTextColor}" />
-                            </Grid>
-                        </Border>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-        </VerticalStackLayout>
+
+                <Border StrokeShape="RoundRectangle 24" Padding="24">
+                    <VerticalStackLayout Spacing="16">
+                        <Label Text="Movimentações recentes" FontSize="20" FontAttributes="Bold" TextColor="{DynamicResource PrimaryTextColor}" />
+                        <CollectionView ItemsSource="{Binding RecentTransactions}" SelectionMode="None">
+                            <CollectionView.EmptyView>
+                                <Label Text="Nenhuma movimentação encontrada." TextColor="{DynamicResource SecondaryTextColor}" HorizontalOptions="Center" />
+                            </CollectionView.EmptyView>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="domain:Transaction">
+                                    <Border StrokeShape="RoundRectangle 16" Padding="16" Margin="0,0,0,12">
+                                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto">
+                                            <Label Text="{Binding Descricao}" FontAttributes="Bold" TextColor="{DynamicResource PrimaryTextColor}" />
+                                            <Label Grid.Row="1" Text="{Binding Categoria}" TextColor="{DynamicResource SecondaryTextColor}" />
+                                            <Label
+                                                Grid.Column="1"
+                                                Text="{Binding Valor, StringFormat='R$ {0:N2}'}"
+                                                TextColor="{DynamicResource PrimaryTextColor}" />
+                                            <Label
+                                                Grid.Column="1"
+                                                Grid.Row="1"
+                                                Text="{Binding Data, StringFormat='{0:dd/MM}'}"
+                                                TextColor="{DynamicResource SecondaryTextColor}" />
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
+            </VerticalStackLayout>
+
+            <VerticalStackLayout x:Name="SidePanel" Grid.Row="1" Grid.ColumnSpan="2" Spacing="24">
+                <Border StrokeShape="RoundRectangle 24" Padding="24">
+                    <VerticalStackLayout Spacing="16">
+                        <Grid ColumnDefinitions="Auto,*,Auto" VerticalOptions="Center">
+                            <Button Text="◀" Command="{Binding PreviousCalendarMonthCommand}" Style="{StaticResource FilterChipStyle}" />
+                            <Label
+                                Grid.Column="1"
+                                HorizontalOptions="Center"
+                                Text="{Binding CalendarMonth, StringFormat='{0:MMMM yyyy}'}"
+                                FontSize="18"
+                                TextTransform="Capitalize"
+                                TextColor="{DynamicResource PrimaryTextColor}" />
+                            <Button Grid.Column="2" Text="▶" Command="{Binding NextCalendarMonthCommand}" Style="{StaticResource FilterChipStyle}" />
+                        </Grid>
+                        <CollectionView ItemsSource="{Binding CalendarDays}" SelectionMode="None">
+                            <CollectionView.ItemsLayout>
+                                <GridItemsLayout Orientation="Vertical" Span="7" />
+                            </CollectionView.ItemsLayout>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="models:CalendarDay">
+                                    <Border StrokeShape="RoundRectangle 12" Padding="8" Margin="2" Stroke="{DynamicResource CardBorderColor}">
+                                        <Border.Triggers>
+                                            <DataTrigger TargetType="Border" Binding="{Binding IsSelected}" Value="True">
+                                                <Setter Property="BackgroundColor" Value="{DynamicResource AccentColor}" />
+                                                <Setter Property="Stroke" Value="{DynamicResource AccentColor}" />
+                                            </DataTrigger>
+                                            <DataTrigger TargetType="Border" Binding="{Binding IsCurrentMonth}" Value="False">
+                                                <Setter Property="Opacity" Value="0.4" />
+                                            </DataTrigger>
+                                        </Border.Triggers>
+                                        <VerticalStackLayout Spacing="4" HorizontalOptions="Center" VerticalOptions="Center">
+                                            <Label Text="{Binding Date, StringFormat='{0:dd}'}" HorizontalOptions="Center" TextColor="{DynamicResource PrimaryTextColor}" />
+                                            <Label Text="{Binding Total, StringFormat='{0:C0}'}" FontSize="10" TextColor="{DynamicResource SecondaryTextColor}" HorizontalOptions="Center" />
+                                            <BoxView WidthRequest="6" HeightRequest="6" CornerRadius="3" Color="{DynamicResource SuccessColor}" IsVisible="{Binding HasTransactions}" HorizontalOptions="Center" />
+                                        </VerticalStackLayout>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:HomeViewModel}}, Path=SelectCalendarDayCommand}" CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border StrokeShape="RoundRectangle 24" Padding="24">
+                    <VerticalStackLayout Spacing="16">
+                        <Grid ColumnDefinitions="*,Auto" VerticalOptions="Center">
+                            <Label Text="{Binding HighlightedDayLabel}" FontAttributes="Bold" TextColor="{DynamicResource PrimaryTextColor}" />
+                            <Label
+                                Grid.Column="1"
+                                Text="{Binding HighlightedDaySaldo, StringFormat='Saldo {0:C}'}"
+                                TextColor="{DynamicResource AccentColor}" />
+                        </Grid>
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="16">
+                            <Border StrokeShape="RoundRectangle 16" Padding="12">
+                                <VerticalStackLayout Spacing="4">
+                                    <Label Text="Entradas" TextColor="{DynamicResource SecondaryTextColor}" />
+                                    <Label Text="{Binding HighlightedDayEntradas, StringFormat='R$ {0:N2}'}" FontAttributes="Bold" TextColor="{DynamicResource SuccessColor}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border StrokeShape="RoundRectangle 16" Padding="12">
+                                <VerticalStackLayout Spacing="4">
+                                    <Label Text="Saídas" TextColor="{DynamicResource SecondaryTextColor}" />
+                                    <Label Text="{Binding HighlightedDaySaidas, StringFormat='R$ {0:N2}'}" FontAttributes="Bold" TextColor="{DynamicResource DangerColor}" />
+                                </VerticalStackLayout>
+                            </Border>
+                        </Grid>
+                        <CollectionView ItemsSource="{Binding DailyTransactions}" SelectionMode="None">
+                            <CollectionView.EmptyView>
+                                <Label Text="Nenhuma movimentação para a data." TextColor="{DynamicResource SecondaryTextColor}" />
+                            </CollectionView.EmptyView>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="domain:Transaction">
+                                    <Border StrokeShape="RoundRectangle 16" Padding="16" Margin="0,0,0,12">
+                                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto">
+                                            <Label Text="{Binding Descricao}" FontAttributes="Bold" TextColor="{DynamicResource PrimaryTextColor}" />
+                                            <Label Grid.Row="1" Text="{Binding Categoria}" TextColor="{DynamicResource SecondaryTextColor}" />
+                                            <Label
+                                                Grid.Column="1"
+                                                Text="{Binding Valor, StringFormat='R$ {0:N2}'}"
+                                                TextColor="{DynamicResource PrimaryTextColor}" />
+                                            <Label
+                                                Grid.Column="1"
+                                                Grid.Row="1"
+                                                Text="{Binding Data, StringFormat='{0:HH:mm}'}"
+                                                TextColor="{DynamicResource SecondaryTextColor}" />
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
+            </VerticalStackLayout>
+        </Grid>
     </ScrollView>
 </ContentPage>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Finace David — Dashboard Financeira</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <span class="logo">FD</span>
+          <div>
+            <strong>Finace David</strong>
+            <small>Gestão premium</small>
+          </div>
+        </div>
+        <nav class="sidebar-nav">
+          <a href="#" class="active">
+            <span>Dashboard</span>
+            <small>Visão geral</small>
+          </a>
+          <a href="#">
+            <span>Transações</span>
+            <small>Histórico completo</small>
+          </a>
+          <a href="#">
+            <span>Contas</span>
+            <small>Pagamentos e cobranças</small>
+          </a>
+          <a href="#">
+            <span>Relatórios</span>
+            <small>Insights avançados</small>
+          </a>
+        </nav>
+        <div class="sidebar-footer">
+          <p>Atualizado há <strong>2 minutos</strong>.</p>
+          <button class="btn-outline">Exportar Relatório</button>
+        </div>
+      </aside>
+      <main class="content">
+        <header class="top-bar">
+          <div>
+            <h1>Central Financeira</h1>
+            <p class="subtitle">Acompanhe entradas, saídas e compromissos em tempo real.</p>
+          </div>
+          <div class="top-actions">
+            <button class="btn-ghost" id="themeToggle" aria-label="Alternar tema">
+              <span class="icon">🌙</span>
+            </button>
+            <div class="profile-card">
+              <div class="avatar">D</div>
+              <div>
+                <strong>David Breno</strong>
+                <small>Diretor Financeiro</small>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section class="quick-links" aria-label="Seletor de visão">
+          <button class="quick-link active" data-view="resumo">
+            <span class="icon">📊</span>
+            Resumo
+          </button>
+          <button class="quick-link" data-view="entrada">
+            <span class="icon">⬆️</span>
+            Entrada
+          </button>
+          <button class="quick-link" data-view="saida">
+            <span class="icon">⬇️</span>
+            Saída
+          </button>
+          <button class="quick-link" data-view="contas">
+            <span class="icon">📅</span>
+            Contas a pagar
+          </button>
+        </section>
+
+        <section class="cards" aria-label="Indicadores principais">
+          <article class="card" data-card="saldo">
+            <header>
+              <span class="label">Saldo atual</span>
+              <span class="pill positive">▲ <span data-field="saldoVariation">+8,3%</span></span>
+            </header>
+            <div class="value" data-field="saldoValue">R$ 185.420,32</div>
+            <footer>
+              <span>Disponível em caixa</span>
+              <span class="secondary">Atualizado hoje</span>
+            </footer>
+          </article>
+          <article class="card" data-card="entradas">
+            <header>
+              <span class="label">Entradas</span>
+              <span class="pill positive">▲ <span data-field="entradaVariation">+12,4%</span></span>
+            </header>
+            <div class="value" data-field="entradaValue">R$ 72.900,00</div>
+            <footer>
+              <span>Ticket médio</span>
+              <span class="secondary" data-field="entradaAverage">R$ 3.040,00</span>
+            </footer>
+          </article>
+          <article class="card" data-card="saidas">
+            <header>
+              <span class="label">Saídas</span>
+              <span class="pill negative">▼ <span data-field="saidaVariation">-4,1%</span></span>
+            </header>
+            <div class="value" data-field="saidaValue">R$ 38.450,00</div>
+            <footer>
+              <span>Principais centros</span>
+              <span class="secondary" data-field="saidaTop">Marketing, Operações</span>
+            </footer>
+          </article>
+          <article class="card" data-card="contas">
+            <header>
+              <span class="label">Contas a pagar</span>
+              <span class="pill warning">⚠ <span data-field="contasDue">3 vencendo</span></span>
+            </header>
+            <div class="value" data-field="contasValue">R$ 24.230,00</div>
+            <footer>
+              <span>Agendadas para esta semana</span>
+              <span class="secondary" data-field="contasNext">Folha, Software, Energia</span>
+            </footer>
+          </article>
+        </section>
+
+        <section class="grid">
+          <article class="panel chart" aria-label="Desempenho mensal">
+            <header>
+              <div>
+                <h2 id="lineChartTitle">Evolução de entradas e saídas</h2>
+                <p class="secondary" id="lineChartSubtitle">Últimos 12 meses</p>
+              </div>
+              <div class="chip-group" role="group" aria-label="Escala temporal">
+                <button class="chip active" data-range="12">12 meses</button>
+                <button class="chip" data-range="6">6 meses</button>
+                <button class="chip" data-range="3">3 meses</button>
+              </div>
+            </header>
+            <canvas id="lineChart" height="260" role="img" aria-label="Gráfico de linhas com evolução financeira"></canvas>
+          </article>
+
+          <article class="panel chart" aria-label="Distribuição por categoria">
+            <header>
+              <div>
+                <h2 id="donutChartTitle">Distribuição por categoria</h2>
+                <p class="secondary" id="donutChartSubtitle">Top categorias</p>
+              </div>
+            </header>
+            <canvas id="donutChart" height="260" role="img" aria-label="Gráfico em rosca com distribuição"></canvas>
+          </article>
+
+          <article class="panel calendar" aria-label="Calendário financeiro">
+            <header>
+              <div>
+                <h2>Calendário inteligente</h2>
+                <p class="secondary">Clique nos dias para ver detalhes</p>
+              </div>
+              <div class="calendar-nav">
+                <button class="btn-ghost" id="prevMonth" aria-label="Mês anterior">◀</button>
+                <span id="calendarMonth" aria-live="polite">Abril 2025</span>
+                <button class="btn-ghost" id="nextMonth" aria-label="Próximo mês">▶</button>
+              </div>
+            </header>
+            <div class="calendar-grid" role="grid" aria-labelledby="calendarMonth"></div>
+            <div class="calendar-legend">
+              <span><i class="dot positive"></i>Entrada</span>
+              <span><i class="dot negative"></i>Saída</span>
+              <span><i class="dot warning"></i>Conta a pagar</span>
+            </div>
+            <div class="calendar-details" aria-live="polite">
+              <h3>Detalhes do dia</h3>
+              <ul id="calendarDetails"></ul>
+            </div>
+          </article>
+
+          <article class="panel activity" aria-label="Linha do tempo de atividades">
+            <header>
+              <div>
+                <h2>Últimos movimentos</h2>
+                <p class="secondary">Atualizado continuamente</p>
+              </div>
+            </header>
+            <ul class="timeline" id="activityTimeline"></ul>
+          </article>
+        </section>
+      </main>
+    </div>
+    <div class="chart-tooltip" id="chartTooltip" role="status" aria-hidden="true"></div>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,972 @@
+const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+  minimumFractionDigits: 2,
+});
+
+const percentFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+function formatCurrency(value) {
+  return currencyFormatter.format(value);
+}
+
+function formatPercent(value) {
+  const formatted = percentFormatter.format(Math.abs(value));
+  return `${value >= 0 ? '+' : '-'}${formatted}`;
+}
+
+function createMonthlyLabels(count) {
+  const labels = [];
+  const base = new Date();
+  for (let i = count - 1; i >= 0; i -= 1) {
+    const date = new Date(base.getFullYear(), base.getMonth() - i, 1);
+    labels.push(
+      new Intl.DateTimeFormat('pt-BR', { month: 'short' })
+        .format(date)
+        .replace('.', '')
+    );
+  }
+  return labels;
+}
+
+const monthlyLabels = createMonthlyLabels(12);
+
+const financeData = {
+  resumo: {
+    highlightCard: null,
+    titles: {
+      lineTitle: 'Evolução de entradas e saídas',
+      lineSubtitle: 'Últimos 12 meses',
+      donutTitle: 'Composição de receitas e despesas',
+      donutSubtitle: 'Distribuição consolidada',
+    },
+    cards: {
+      saldoValue: { type: 'currency', value: 185420.32 },
+      saldoVariation: { type: 'percent', value: 0.083 },
+      entradaValue: { type: 'currency', value: 72900 },
+      entradaVariation: { type: 'percent', value: 0.124 },
+      entradaAverage: { type: 'currency', value: 3040 },
+      saidaValue: { type: 'currency', value: 38450 },
+      saidaVariation: { type: 'percent', value: -0.041 },
+      saidaTop: { type: 'text', value: 'Marketing, Operações' },
+      contasValue: { type: 'currency', value: 24230 },
+      contasDue: { type: 'text', value: '3 vencendo' },
+      contasNext: { type: 'text', value: 'Folha, Software, Energia' },
+    },
+    line: {
+      labels: monthlyLabels,
+      datasets: [
+        {
+          label: 'Entradas',
+          data: [42000, 43200, 44500, 46800, 48120, 50210, 51980, 53870, 55240, 56910, 58900, 61240],
+          borderColor: 'rgba(16, 185, 129, 1)',
+          backgroundColor: 'rgba(16, 185, 129, 0.2)',
+          tension: 0.4,
+          fill: true,
+        },
+        {
+          label: 'Saídas',
+          data: [27500, 29200, 30550, 32100, 33450, 34900, 35220, 36110, 36840, 37250, 37800, 38450],
+          borderColor: 'rgba(248, 113, 113, 1)',
+          backgroundColor: 'rgba(248, 113, 113, 0.18)',
+          tension: 0.4,
+          fill: true,
+        },
+      ],
+    },
+    donut: {
+      labels: ['Consultorias', 'Investimentos', 'Produtos digitais', 'Serviços recorrentes'],
+      data: [32000, 19000, 14500, 7400],
+      colors: ['#10b981', '#6366f1', '#f97316', '#ec4899'],
+    },
+    events: [
+      { date: '2025-04-02', type: 'entrada', title: 'Consultoria XPTO', amount: 8200 },
+      { date: '2025-04-03', type: 'contas', title: 'Folha de pagamento', amount: 15800 },
+      { date: '2025-04-04', type: 'saida', title: 'Campanha de mídia', amount: 6200 },
+      { date: '2025-04-08', type: 'entrada', title: 'Licenças anuais', amount: 12400 },
+      { date: '2025-04-09', type: 'contas', title: 'Software ERP', amount: 3400 },
+      { date: '2025-04-10', type: 'saida', title: 'Infraestrutura cloud', amount: 4100 },
+      { date: '2025-04-15', type: 'entrada', title: 'Mentoria executiva', amount: 5300 },
+      { date: '2025-04-17', type: 'contas', title: 'Energia elétrica', amount: 1870 },
+      { date: '2025-04-18', type: 'saida', title: 'Treinamento time', amount: 2200 },
+      { date: '2025-04-22', type: 'entrada', title: 'Royalties plataforma', amount: 9100 },
+      { date: '2025-04-24', type: 'saida', title: 'Serviços jurídicos', amount: 1800 },
+      { date: '2025-04-26', type: 'contas', title: 'Impostos municipais', amount: 4600 },
+    ],
+    timeline: [
+      { title: 'Entrada confirmada', detail: 'Consultoria XPTO', type: 'entrada', amount: 8200, time: 'há 8 minutos' },
+      { title: 'Conta paga', detail: 'Energia elétrica', type: 'contas', amount: -1870, time: 'há 34 minutos' },
+      { title: 'Revisão de orçamento', detail: 'Marketing atualizado', type: 'saida', amount: -2100, time: 'há 1 hora' },
+      { title: 'Projeção mensal', detail: 'Saldo previsto ajustado', type: 'entrada', amount: 0, time: 'há 2 horas' },
+    ],
+  },
+  entrada: {
+    highlightCard: 'entradas',
+    titles: {
+      lineTitle: 'Entradas confirmadas',
+      lineSubtitle: 'Fluxo de recebimentos',
+      donutTitle: 'Receitas por origem',
+      donutSubtitle: 'Top 4 contratos',
+    },
+    cards: {
+      saldoValue: { type: 'currency', value: 185420.32 },
+      saldoVariation: { type: 'percent', value: 0.083 },
+      entradaValue: { type: 'currency', value: 61240 },
+      entradaVariation: { type: 'percent', value: 0.162 },
+      entradaAverage: { type: 'currency', value: 5120 },
+      saidaValue: { type: 'currency', value: 38450 },
+      saidaVariation: { type: 'percent', value: -0.041 },
+      saidaTop: { type: 'text', value: 'Campanhas, Operações' },
+      contasValue: { type: 'currency', value: 21200 },
+      contasDue: { type: 'text', value: '2 vencendo' },
+      contasNext: { type: 'text', value: 'Folha, Fornecedores' },
+    },
+    line: {
+      labels: monthlyLabels,
+      datasets: [
+        {
+          label: 'Entradas',
+          data: [32000, 33800, 35100, 36500, 37900, 39400, 41200, 42500, 43800, 45200, 48000, 61240],
+          borderColor: 'rgba(16, 185, 129, 1)',
+          backgroundColor: 'rgba(16, 185, 129, 0.2)',
+          tension: 0.45,
+          fill: true,
+        },
+      ],
+    },
+    donut: {
+      labels: ['Consultorias premium', 'Mentorias', 'Royalties', 'Produtos digitais'],
+      data: [22000, 13500, 15800, 9940],
+      colors: ['#10b981', '#22d3ee', '#6366f1', '#f472b6'],
+    },
+    events: [
+      { date: '2025-04-02', type: 'entrada', title: 'Consultoria XPTO', amount: 8200 },
+      { date: '2025-04-08', type: 'entrada', title: 'Licenças anuais', amount: 12400 },
+      { date: '2025-04-15', type: 'entrada', title: 'Mentoria executiva', amount: 5300 },
+      { date: '2025-04-22', type: 'entrada', title: 'Royalties plataforma', amount: 9100 },
+      { date: '2025-04-27', type: 'entrada', title: 'Investidor estratégico', amount: 13200 },
+    ],
+    timeline: [
+      { title: 'Contrato fechado', detail: 'Mentoria scale-up', type: 'entrada', amount: 6800, time: 'há 12 minutos' },
+      { title: 'Recorrência processada', detail: 'Produtos digitais', type: 'entrada', amount: 4200, time: 'há 48 minutos' },
+      { title: 'Entrada confirmada', detail: 'Investidor estratégico', type: 'entrada', amount: 13200, time: 'há 2 horas' },
+      { title: 'Previsão ajustada', detail: 'Projeção trimestral', type: 'entrada', amount: 0, time: 'há 5 horas' },
+    ],
+  },
+  saida: {
+    highlightCard: 'saidas',
+    titles: {
+      lineTitle: 'Saídas controladas',
+      lineSubtitle: 'Compromissos liquidados',
+      donutTitle: 'Saídas por centro de custo',
+      donutSubtitle: 'Visão do mês corrente',
+    },
+    cards: {
+      saldoValue: { type: 'currency', value: 172980.12 },
+      saldoVariation: { type: 'percent', value: 0.052 },
+      entradaValue: { type: 'currency', value: 61240 },
+      entradaVariation: { type: 'percent', value: 0.098 },
+      entradaAverage: { type: 'currency', value: 4580 },
+      saidaValue: { type: 'currency', value: 34220 },
+      saidaVariation: { type: 'percent', value: -0.068 },
+      saidaTop: { type: 'text', value: 'Operações, Marketing, Pessoas' },
+      contasValue: { type: 'currency', value: 19890 },
+      contasDue: { type: 'text', value: '1 vencendo' },
+      contasNext: { type: 'text', value: 'Infra, Jurídico, Tributos' },
+    },
+    line: {
+      labels: monthlyLabels,
+      datasets: [
+        {
+          label: 'Saídas',
+          data: [26800, 27900, 28800, 29640, 30500, 31420, 32200, 33100, 33820, 34220, 34980, 35200],
+          borderColor: 'rgba(248, 113, 113, 1)',
+          backgroundColor: 'rgba(248, 113, 113, 0.18)',
+          tension: 0.45,
+          fill: true,
+        },
+      ],
+    },
+    donut: {
+      labels: ['Operações', 'Marketing', 'Pessoas', 'Tecnologia'],
+      data: [11800, 8200, 7600, 5620],
+      colors: ['#f97316', '#fb7185', '#facc15', '#6366f1'],
+    },
+    events: [
+      { date: '2025-04-04', type: 'saida', title: 'Campanha de mídia', amount: 6200 },
+      { date: '2025-04-10', type: 'saida', title: 'Infraestrutura cloud', amount: 4100 },
+      { date: '2025-04-12', type: 'saida', title: 'Equipe de produto', amount: 5200 },
+      { date: '2025-04-18', type: 'saida', title: 'Treinamento time', amount: 2200 },
+      { date: '2025-04-24', type: 'saida', title: 'Serviços jurídicos', amount: 1800 },
+    ],
+    timeline: [
+      { title: 'Pagamento efetuado', detail: 'Infraestrutura cloud', type: 'saida', amount: -4100, time: 'há 18 minutos' },
+      { title: 'Equipe bonificada', detail: 'Programa de talentos', type: 'saida', amount: -5200, time: 'há 1 hora' },
+      { title: 'Campanha aprovada', detail: 'Marketing performance', type: 'saida', amount: -6200, time: 'há 3 horas' },
+      { title: 'Auditoria concluída', detail: 'Compliance mensal', type: 'saida', amount: 0, time: 'há 5 horas' },
+    ],
+  },
+  contas: {
+    highlightCard: 'contas',
+    titles: {
+      lineTitle: 'Contas programadas',
+      lineSubtitle: 'Previsão de pagamentos',
+      donutTitle: 'Status das contas',
+      donutSubtitle: 'Situação desta semana',
+    },
+    cards: {
+      saldoValue: { type: 'currency', value: 162300.55 },
+      saldoVariation: { type: 'percent', value: 0.037 },
+      entradaValue: { type: 'currency', value: 58900 },
+      entradaVariation: { type: 'percent', value: 0.074 },
+      entradaAverage: { type: 'currency', value: 4080 },
+      saidaValue: { type: 'currency', value: 31200 },
+      saidaVariation: { type: 'percent', value: -0.031 },
+      saidaTop: { type: 'text', value: 'Infra, Pessoas, Serviços' },
+      contasValue: { type: 'currency', value: 24230 },
+      contasDue: { type: 'text', value: '3 vencendo' },
+      contasNext: { type: 'text', value: 'Folha, ERP, Tributos' },
+    },
+    line: {
+      labels: monthlyLabels,
+      datasets: [
+        {
+          label: 'Contas previstas',
+          data: [18200, 19400, 20100, 21900, 22500, 23100, 24000, 24600, 25500, 26200, 23800, 24230],
+          borderColor: 'rgba(250, 204, 21, 1)',
+          backgroundColor: 'rgba(250, 204, 21, 0.18)',
+          tension: 0.4,
+          fill: true,
+        },
+      ],
+    },
+    donut: {
+      labels: ['Vencidas', 'Vencendo', 'Programadas', 'Provisionadas'],
+      data: [6400, 8200, 5200, 3430],
+      colors: ['#f87171', '#facc15', '#60a5fa', '#a855f7'],
+    },
+    events: [
+      { date: '2025-04-03', type: 'contas', title: 'Folha de pagamento', amount: 15800 },
+      { date: '2025-04-09', type: 'contas', title: 'Software ERP', amount: 3400 },
+      { date: '2025-04-17', type: 'contas', title: 'Energia elétrica', amount: 1870 },
+      { date: '2025-04-21', type: 'contas', title: 'Serviços contábeis', amount: 920 },
+      { date: '2025-04-26', type: 'contas', title: 'Impostos municipais', amount: 4600 },
+    ],
+    timeline: [
+      { title: 'Conta programada', detail: 'Serviços contábeis', type: 'contas', amount: -920, time: 'há 20 minutos' },
+      { title: 'Pagamento agendado', detail: 'Folha de pagamento', type: 'contas', amount: -15800, time: 'há 2 horas' },
+      { title: 'Alerta gerado', detail: 'Impostos municipais', type: 'contas', amount: -4600, time: 'há 4 horas' },
+      { title: 'Negociação concluída', detail: 'Software ERP', type: 'contas', amount: -3400, time: 'há 6 horas' },
+    ],
+  },
+};
+
+const quickLinks = document.querySelectorAll('.quick-link');
+const cards = document.querySelectorAll('.card');
+const chips = document.querySelectorAll('.chip');
+const lineChartTitle = document.getElementById('lineChartTitle');
+const lineChartSubtitle = document.getElementById('lineChartSubtitle');
+const donutChartTitle = document.getElementById('donutChartTitle');
+const donutChartSubtitle = document.getElementById('donutChartSubtitle');
+const calendarMonth = document.getElementById('calendarMonth');
+const calendarGrid = document.querySelector('.calendar-grid');
+const calendarDetails = document.getElementById('calendarDetails');
+const activityTimeline = document.getElementById('activityTimeline');
+const themeToggle = document.getElementById('themeToggle');
+const lineCanvas = document.getElementById('lineChart');
+const donutCanvas = document.getElementById('donutChart');
+const chartTooltip = document.getElementById('chartTooltip');
+
+let currentView = 'resumo';
+let currentRange = 12;
+let currentDate = new Date(financeData.resumo.events[0].date);
+
+const lineChartState = {
+  labels: [],
+  datasets: [],
+  hitPoints: [],
+  activePointKey: null,
+  scheduled: false,
+};
+
+const donutChartState = {
+  labels: [],
+  data: [],
+  colors: [],
+  total: 0,
+  segments: [],
+  activeIndex: null,
+  scheduled: false,
+  geometry: null,
+};
+
+const donutRotation = -Math.PI / 2;
+
+function prepareCanvas(canvas) {
+  const rect = canvas.getBoundingClientRect();
+  const width = rect.width || canvas.width;
+  const height = rect.height || canvas.height;
+  const dpr = window.devicePixelRatio || 1;
+  const targetWidth = Math.max(1, Math.round(width * dpr));
+  const targetHeight = Math.max(1, Math.round(height * dpr));
+  if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+  }
+  const ctx = canvas.getContext('2d');
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, width, height);
+  return { ctx, width, height };
+}
+
+function getThemeColor(variable) {
+  return getComputedStyle(document.body).getPropertyValue(variable).trim() || '#94a3b8';
+}
+
+function positionTooltip(clientX, clientY) {
+  if (!chartTooltip) return;
+  const tooltipRect = chartTooltip.getBoundingClientRect();
+  const offset = 16;
+  let left = clientX + offset;
+  let top = clientY + offset;
+  if (left + tooltipRect.width > window.innerWidth - 12) {
+    left = clientX - tooltipRect.width - offset;
+  }
+  if (top + tooltipRect.height > window.innerHeight - 12) {
+    top = clientY - tooltipRect.height - offset;
+  }
+  chartTooltip.style.transform = `translate(${Math.max(12, left)}px, ${Math.max(12, top)}px)`;
+}
+
+function showTooltip(content, clientX, clientY) {
+  if (!chartTooltip) return;
+  chartTooltip.innerHTML = content;
+  chartTooltip.classList.add('visible');
+  chartTooltip.setAttribute('aria-hidden', 'false');
+  positionTooltip(clientX, clientY);
+}
+
+function hideTooltip() {
+  if (!chartTooltip) return;
+  chartTooltip.classList.remove('visible');
+  chartTooltip.setAttribute('aria-hidden', 'true');
+  chartTooltip.style.transform = 'translate(-9999px, -9999px)';
+}
+
+function renderLineChart() {
+  if (!lineCanvas) return;
+  const { ctx, width, height } = prepareCanvas(lineCanvas);
+  const padding = { top: 32, right: 28, bottom: 52, left: 68 };
+  const chartWidth = Math.max(0, width - padding.left - padding.right);
+  const chartHeight = Math.max(0, height - padding.top - padding.bottom);
+  const chartLeft = padding.left;
+  const chartBottom = height - padding.bottom;
+  const chartTop = padding.top;
+
+  const labels = lineChartState.labels;
+  const datasets = lineChartState.datasets;
+  lineChartState.hitPoints = [];
+
+  if (!labels.length || !datasets.length) {
+    ctx.fillStyle = getThemeColor('--text-soft');
+    ctx.font = '500 14px "Inter", system-ui';
+    ctx.textAlign = 'center';
+    ctx.fillText('Sem dados suficientes para exibir o gráfico.', width / 2, height / 2);
+    return;
+  }
+
+  const allValues = datasets.flatMap((dataset) => dataset.data);
+  const maxValue = Math.max(...allValues);
+  const minValue = Math.min(...allValues);
+  const valueRange = maxValue - minValue || maxValue || 1;
+  const upperBound = maxValue + valueRange * 0.1;
+  const lowerBound = Math.max(0, minValue - valueRange * 0.1);
+  const span = Math.max(upperBound - lowerBound, 1);
+
+  const gridColor = 'rgba(148, 163, 184, 0.16)';
+  const axisColor = getThemeColor('--text-soft');
+
+  const steps = 4;
+  ctx.strokeStyle = gridColor;
+  ctx.lineWidth = 1;
+  ctx.setLineDash([4, 6]);
+  for (let step = 0; step <= steps; step += 1) {
+    const ratio = step / steps;
+    const y = chartBottom - ratio * chartHeight;
+    ctx.beginPath();
+    ctx.moveTo(chartLeft, y);
+    ctx.lineTo(chartLeft + chartWidth, y);
+    ctx.stroke();
+    const value = lowerBound + (upperBound - lowerBound) * ratio;
+    ctx.save();
+    ctx.setLineDash([]);
+    ctx.fillStyle = axisColor;
+    ctx.font = '500 12px "Inter", system-ui';
+    ctx.textAlign = 'right';
+    ctx.fillText(formatCurrency(value), chartLeft - 12, y + 4);
+    ctx.restore();
+  }
+  ctx.setLineDash([]);
+
+  const labelCount = labels.length;
+  const stepX = labelCount > 1 ? chartWidth / (labelCount - 1) : 0;
+  ctx.fillStyle = axisColor;
+  ctx.font = '500 12px "Inter", system-ui';
+  ctx.textAlign = 'center';
+  labels.forEach((label, index) => {
+    const x = chartLeft + (labelCount > 1 ? index * stepX : chartWidth / 2);
+    ctx.fillText(label, x, chartBottom + 32);
+  });
+
+  const datasetPoints = [];
+  datasets.forEach((dataset, datasetIndex) => {
+    const points = dataset.data.map((value, index) => {
+      const ratio = (value - lowerBound) / span;
+      const x = chartLeft + (labelCount > 1 ? index * stepX : chartWidth / 2);
+      const y = chartBottom - ratio * chartHeight;
+      const point = {
+        x,
+        y,
+        value,
+        datasetIndex,
+        labelIndex: index,
+        label: labels[index],
+        datasetLabel: dataset.label,
+        color: dataset.borderColor,
+        key: `${datasetIndex}-${index}`,
+      };
+      lineChartState.hitPoints.push(point);
+      return point;
+    });
+    datasetPoints.push({ dataset, points });
+  });
+
+  datasetPoints.forEach(({ dataset, points }) => {
+    if (dataset.fill && dataset.backgroundColor && points.length) {
+      ctx.beginPath();
+      ctx.moveTo(points[0].x, chartBottom);
+      points.forEach((point) => ctx.lineTo(point.x, point.y));
+      ctx.lineTo(points[points.length - 1].x, chartBottom);
+      ctx.closePath();
+      ctx.fillStyle = dataset.backgroundColor;
+      ctx.fill();
+    }
+
+    ctx.beginPath();
+    points.forEach((point, index) => {
+      if (index === 0) {
+        ctx.moveTo(point.x, point.y);
+      } else {
+        ctx.lineTo(point.x, point.y);
+      }
+    });
+    ctx.lineWidth = 2.5;
+    ctx.strokeStyle = dataset.borderColor || '#7c3aed';
+    ctx.stroke();
+  });
+
+  ctx.fillStyle = axisColor;
+  ctx.fillRect(chartLeft, chartBottom, chartWidth, 1);
+
+  if (lineChartState.activePointKey) {
+    const active = lineChartState.hitPoints.find((point) => point.key === lineChartState.activePointKey);
+    if (active) {
+      ctx.save();
+      ctx.strokeStyle = 'rgba(148, 163, 184, 0.35)';
+      ctx.setLineDash([4, 6]);
+      ctx.beginPath();
+      ctx.moveTo(active.x, chartTop);
+      ctx.lineTo(active.x, chartBottom);
+      ctx.stroke();
+      ctx.restore();
+
+      ctx.save();
+      ctx.fillStyle = active.color || '#7c3aed';
+      ctx.beginPath();
+      ctx.arc(active.x, active.y, 6, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = 'rgba(15, 23, 42, 0.85)';
+      ctx.stroke();
+      ctx.restore();
+    }
+  }
+}
+
+function renderDonutChart() {
+  if (!donutCanvas) return;
+  const { ctx, width, height } = prepareCanvas(donutCanvas);
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const radius = Math.max(0, Math.min(width, height) / 2 - 16);
+  const innerRadius = radius * 0.58;
+  donutChartState.geometry = { centerX, centerY, radius, innerRadius };
+
+  const { labels, data, colors, activeIndex, total } = donutChartState;
+  donutChartState.segments = [];
+
+  if (!data.length || total === 0) {
+    ctx.fillStyle = getThemeColor('--text-soft');
+    ctx.font = '500 14px "Inter", system-ui';
+    ctx.textAlign = 'center';
+    ctx.fillText('Sem dados suficientes para exibir o gráfico.', centerX, centerY);
+    return;
+  }
+
+  let startAngle = 0;
+  data.forEach((value, index) => {
+    const portion = value / total;
+    const segment = {
+      start: startAngle,
+      end: startAngle + portion * Math.PI * 2,
+      label: labels[index],
+      value,
+      color: colors[index],
+      index,
+    };
+    donutChartState.segments.push(segment);
+    startAngle = segment.end;
+  });
+
+  donutChartState.segments.forEach((segment) => {
+    const isActive = segment.index === activeIndex;
+    const displayRadius = isActive ? radius + 6 : radius;
+    const start = donutRotation + segment.start;
+    const end = donutRotation + segment.end;
+
+    ctx.beginPath();
+    ctx.moveTo(centerX, centerY);
+    ctx.arc(centerX, centerY, displayRadius, start, end);
+    ctx.arc(centerX, centerY, innerRadius, end, start, true);
+    ctx.closePath();
+    ctx.fillStyle = segment.color;
+    ctx.globalAlpha = isActive ? 0.95 : 0.82;
+    ctx.fill();
+    ctx.globalAlpha = 1;
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = 'rgba(15, 23, 42, 0.35)';
+    ctx.stroke();
+  });
+
+  ctx.fillStyle = getThemeColor('--text');
+  ctx.font = '700 18px "Inter", system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText(formatCurrency(total), centerX, centerY - 4);
+
+  ctx.fillStyle = getThemeColor('--text-soft');
+  ctx.font = '500 12px "Inter", system-ui';
+  ctx.fillText('Total movimentado', centerX, centerY + 18);
+}
+
+function scheduleLineChartRender() {
+  if (lineChartState.scheduled) return;
+  lineChartState.scheduled = true;
+  requestAnimationFrame(() => {
+    lineChartState.scheduled = false;
+    renderLineChart();
+  });
+}
+
+function scheduleDonutChartRender() {
+  if (donutChartState.scheduled) return;
+  donutChartState.scheduled = true;
+  requestAnimationFrame(() => {
+    donutChartState.scheduled = false;
+    renderDonutChart();
+  });
+}
+
+function handleLineHover(event) {
+  if (!lineCanvas) return;
+  const rect = lineCanvas.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+  const tolerance = 18;
+  let nearest = null;
+
+  lineChartState.hitPoints.forEach((point) => {
+    const distance = Math.hypot(point.x - x, point.y - y);
+    if (distance <= tolerance && (!nearest || distance < nearest.distance)) {
+      nearest = { ...point, distance };
+    }
+  });
+
+  if (nearest) {
+    if (lineChartState.activePointKey !== nearest.key) {
+      lineChartState.activePointKey = nearest.key;
+      scheduleLineChartRender();
+    }
+    showTooltip(
+      `<strong>${nearest.datasetLabel}</strong><span>${nearest.label}</span><span>${formatCurrency(nearest.value)}</span>`,
+      event.clientX,
+      event.clientY
+    );
+  } else {
+    if (lineChartState.activePointKey) {
+      lineChartState.activePointKey = null;
+      scheduleLineChartRender();
+    }
+    hideTooltip();
+  }
+}
+
+function handleLineLeave() {
+  if (lineChartState.activePointKey) {
+    lineChartState.activePointKey = null;
+    scheduleLineChartRender();
+  }
+  hideTooltip();
+}
+
+function handleDonutHover(event) {
+  if (!donutCanvas || !donutChartState.geometry) return;
+  const rect = donutCanvas.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+  const { centerX, centerY, radius, innerRadius } = donutChartState.geometry;
+  const dx = x - centerX;
+  const dy = y - centerY;
+  const distance = Math.sqrt(dx * dx + dy * dy);
+
+  if (distance < innerRadius || distance > radius + 8) {
+    if (donutChartState.activeIndex !== null) {
+      donutChartState.activeIndex = null;
+      scheduleDonutChartRender();
+    }
+    hideTooltip();
+    return;
+  }
+
+  let angle = Math.atan2(dy, dx) - donutRotation;
+  if (angle < 0) angle += Math.PI * 2;
+
+  const segment = donutChartState.segments.find((item) => angle >= item.start && angle < item.end);
+  if (segment) {
+    if (donutChartState.activeIndex !== segment.index) {
+      donutChartState.activeIndex = segment.index;
+      scheduleDonutChartRender();
+    }
+    const percentage = donutChartState.total ? ((segment.value / donutChartState.total) * 100).toFixed(1) : '0.0';
+    showTooltip(
+      `<strong>${segment.label}</strong><span>${formatCurrency(segment.value)} · ${percentage}%</span>`,
+      event.clientX,
+      event.clientY
+    );
+  } else {
+    if (donutChartState.activeIndex !== null) {
+      donutChartState.activeIndex = null;
+      scheduleDonutChartRender();
+    }
+    hideTooltip();
+  }
+}
+
+function handleDonutLeave() {
+  if (donutChartState.activeIndex !== null) {
+    donutChartState.activeIndex = null;
+    scheduleDonutChartRender();
+  }
+  hideTooltip();
+}
+
+function applyRange(data, range) {
+  return data.slice(-range);
+}
+
+function updateCards(viewKey) {
+  const data = financeData[viewKey].cards;
+  Object.entries(data).forEach(([key, descriptor]) => {
+    const target = document.querySelector(`[data-field="${key}"]`);
+    if (!target) return;
+    let text = descriptor.value;
+    switch (descriptor.type) {
+      case 'currency':
+        text = formatCurrency(descriptor.value);
+        break;
+      case 'percent':
+        text = formatPercent(descriptor.value);
+        break;
+      default:
+        text = descriptor.value;
+    }
+    target.textContent = text;
+  });
+
+  cards.forEach((card) => {
+    const key = financeData[viewKey].highlightCard;
+    card.classList.toggle('focus', key && card.dataset.card === key);
+  });
+}
+
+function updateLineChart(viewKey) {
+  const { line } = financeData[viewKey];
+  const labels = applyRange(line.labels, currentRange);
+  const datasets = line.datasets.map((dataset) => ({
+    ...dataset,
+    data: applyRange(dataset.data, currentRange),
+  }));
+
+  lineChartState.labels = labels;
+  lineChartState.datasets = datasets;
+  lineChartState.activePointKey = null;
+  scheduleLineChartRender();
+}
+
+function updateDonutChart(viewKey) {
+  const { donut } = financeData[viewKey];
+  donutChartState.labels = donut.labels;
+  donutChartState.data = donut.data;
+  donutChartState.colors = donut.colors;
+  donutChartState.total = donut.data.reduce((acc, value) => acc + value, 0);
+  donutChartState.activeIndex = null;
+  scheduleDonutChartRender();
+}
+
+function renderTimeline(viewKey) {
+  const items = financeData[viewKey].timeline;
+  activityTimeline.innerHTML = '';
+  items.forEach((item) => {
+    const li = document.createElement('li');
+    li.classList.add('timeline-item');
+    const amountText =
+      item.amount === 0
+        ? '—'
+        : `${item.amount > 0 ? '+' : '-'}${formatCurrency(Math.abs(item.amount))}`;
+    li.innerHTML = `
+      <strong>${item.title}</strong>
+      <span class="meta">${item.detail} · ${item.time}</span>
+      <span class="amount ${item.type}">${amountText}</span>
+    `;
+    activityTimeline.appendChild(li);
+  });
+}
+
+function sameDay(a, b) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+function renderCalendar(viewKey) {
+  const events = financeData[viewKey].events;
+  const monthFormat = new Intl.DateTimeFormat('pt-BR', { month: 'long', year: 'numeric' });
+  calendarMonth.textContent = monthFormat
+    .format(currentDate)
+    .replace(/^./, (c) => c.toUpperCase());
+
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+  const start = new Date(year, month, 1);
+  const startOffset = (start.getDay() + 6) % 7; // Monday-first week
+  const totalDays = new Date(year, month + 1, 0).getDate();
+  const totalCells = Math.ceil((startOffset + totalDays) / 7) * 7;
+
+  calendarGrid.innerHTML = '';
+  let firstActiveCell = null;
+
+  for (let cellIndex = 0; cellIndex < totalCells; cellIndex += 1) {
+    const dayNumber = cellIndex - startOffset + 1;
+    const cellDate = new Date(year, month, dayNumber);
+    const isCurrentMonth = dayNumber > 0 && dayNumber <= totalDays;
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'calendar-cell';
+    button.setAttribute('role', 'gridcell');
+
+    if (!isCurrentMonth) {
+      button.classList.add('is-out');
+      button.innerHTML = '<span class="date">&nbsp;</span>';
+      calendarGrid.appendChild(button);
+      continue;
+    }
+
+    const eventsForDay = events.filter((event) => {
+      const eventDate = new Date(event.date);
+      return sameDay(eventDate, cellDate);
+    });
+
+    const net = eventsForDay.reduce((acc, event) => {
+      const direction = event.type === 'entrada' ? 1 : -1;
+      return acc + direction * event.amount;
+    }, 0);
+    const amountLabel = eventsForDay.length
+      ? `${net >= 0 ? '+' : '-'}${formatCurrency(Math.abs(net))}`
+      : '—';
+
+    button.innerHTML = `
+      <span class="date">${String(dayNumber).padStart(2, '0')}</span>
+      <span class="amount">${amountLabel}</span>
+    `;
+
+    const badges = document.createElement('div');
+    badges.className = 'badges';
+    const types = Array.from(new Set(eventsForDay.map((event) => event.type)));
+    types.forEach((type) => {
+      const dot = document.createElement('span');
+      dot.className = `dot ${type === 'contas' ? 'warning' : type === 'entrada' ? 'positive' : 'negative'}`;
+      badges.appendChild(dot);
+    });
+    if (types.length) {
+      button.appendChild(badges);
+    }
+
+    button.addEventListener('click', () => {
+      document.querySelectorAll('.calendar-cell.active').forEach((cell) => cell.classList.remove('active'));
+      button.classList.add('active');
+      renderCalendarDetails(eventsForDay, cellDate);
+    });
+
+    calendarGrid.appendChild(button);
+
+    if (!firstActiveCell && eventsForDay.length) {
+      firstActiveCell = { button, events: eventsForDay, date: cellDate };
+    }
+  }
+
+  if (firstActiveCell) {
+    firstActiveCell.button.classList.add('active');
+    renderCalendarDetails(firstActiveCell.events, firstActiveCell.date);
+  } else {
+    renderCalendarDetails([], currentDate);
+  }
+}
+
+function renderCalendarDetails(events, date) {
+  const dayFormat = new Intl.DateTimeFormat('pt-BR', { day: '2-digit', month: 'long' });
+  calendarDetails.innerHTML = '';
+
+  if (!events.length) {
+    const empty = document.createElement('li');
+    empty.textContent = `${dayFormat.format(date)} • Sem movimentações`;
+    calendarDetails.appendChild(empty);
+    return;
+  }
+
+  events
+    .sort((a, b) => b.amount - a.amount)
+    .forEach((event) => {
+      const item = document.createElement('li');
+      const badgeClass = event.type === 'contas' ? 'warning' : event.type === 'entrada' ? 'positive' : 'negative';
+      const amountText =
+        event.type === 'entrada'
+          ? `+${formatCurrency(event.amount)}`
+          : `-${formatCurrency(event.amount)}`;
+      const formattedDate = dayFormat
+        .format(new Date(event.date))
+        .replace(/^./, (c) => c.toUpperCase());
+      item.innerHTML = `
+        <span>${formattedDate} · ${event.title}</span>
+        <span class="amount ${badgeClass}">${amountText}</span>
+      `;
+      calendarDetails.appendChild(item);
+    });
+}
+
+function updateTitles(viewKey) {
+  const { titles } = financeData[viewKey];
+  lineChartTitle.textContent = titles.lineTitle;
+  lineChartSubtitle.textContent = titles.lineSubtitle;
+  donutChartTitle.textContent = titles.donutTitle;
+  donutChartSubtitle.textContent = titles.donutSubtitle;
+}
+
+function updateView(viewKey) {
+  currentView = viewKey;
+  hideTooltip();
+  updateTitles(viewKey);
+  updateCards(viewKey);
+  updateLineChart(viewKey);
+  updateDonutChart(viewKey);
+  renderTimeline(viewKey);
+  renderCalendar(viewKey);
+}
+
+quickLinks.forEach((link) => {
+  link.addEventListener('click', () => {
+    const view = link.dataset.view;
+    if (view === currentView) return;
+
+    quickLinks.forEach((btn) => btn.classList.remove('active'));
+    link.classList.add('active');
+    updateView(view);
+  });
+});
+
+chips.forEach((chip) => {
+  chip.addEventListener('click', () => {
+    const range = Number(chip.dataset.range);
+    if (range === currentRange) return;
+
+    chips.forEach((item) => item.classList.remove('active'));
+    chip.classList.add('active');
+    currentRange = range;
+    updateLineChart(currentView);
+  });
+});
+
+if (lineCanvas) {
+  lineCanvas.addEventListener('mousemove', handleLineHover);
+  lineCanvas.addEventListener('mouseleave', handleLineLeave);
+  lineCanvas.addEventListener('touchstart', (event) => {
+    if (!event.touches.length) return;
+    handleLineHover(event.touches[0]);
+    event.preventDefault();
+  }, { passive: false });
+  lineCanvas.addEventListener('touchmove', (event) => {
+    if (!event.touches.length) return;
+    handleLineHover(event.touches[0]);
+    event.preventDefault();
+  }, { passive: false });
+  lineCanvas.addEventListener('touchend', handleLineLeave);
+  lineCanvas.addEventListener('touchcancel', handleLineLeave);
+}
+
+if (donutCanvas) {
+  donutCanvas.addEventListener('mousemove', handleDonutHover);
+  donutCanvas.addEventListener('mouseleave', handleDonutLeave);
+  donutCanvas.addEventListener('touchstart', (event) => {
+    if (!event.touches.length) return;
+    handleDonutHover(event.touches[0]);
+    event.preventDefault();
+  }, { passive: false });
+  donutCanvas.addEventListener('touchmove', (event) => {
+    if (!event.touches.length) return;
+    handleDonutHover(event.touches[0]);
+    event.preventDefault();
+  }, { passive: false });
+  donutCanvas.addEventListener('touchend', handleDonutLeave);
+  donutCanvas.addEventListener('touchcancel', handleDonutLeave);
+}
+
+if (window.ResizeObserver) {
+  const lineObserver = new ResizeObserver(() => scheduleLineChartRender());
+  const donutObserver = new ResizeObserver(() => scheduleDonutChartRender());
+  if (lineCanvas?.parentElement) lineObserver.observe(lineCanvas.parentElement);
+  if (donutCanvas?.parentElement) donutObserver.observe(donutCanvas.parentElement);
+}
+
+window.addEventListener('resize', () => {
+  scheduleLineChartRender();
+  scheduleDonutChartRender();
+});
+
+function shiftMonth(delta) {
+  currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth() + delta, 1);
+  renderCalendar(currentView);
+}
+
+document.getElementById('prevMonth').addEventListener('click', () => shiftMonth(-1));
+document.getElementById('nextMonth').addEventListener('click', () => shiftMonth(1));
+
+themeToggle.addEventListener('click', () => {
+  document.body.classList.toggle('light');
+  themeToggle.querySelector('.icon').textContent = document.body.classList.contains('light') ? '🌞' : '🌙';
+  scheduleLineChartRender();
+  scheduleDonutChartRender();
+  hideTooltip();
+});
+
+updateView('resumo');

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,665 @@
+:root {
+  color-scheme: dark;
+  --bg: #080c18;
+  --bg-elevated: rgba(17, 24, 39, 0.75);
+  --bg-panel: rgba(21, 32, 53, 0.8);
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #f9fafb;
+  --text-soft: #9ca3af;
+  --accent: #7c3aed;
+  --accent-soft: rgba(124, 58, 237, 0.16);
+  --positive: #10b981;
+  --negative: #f97316;
+  --warning: #facc15;
+  --shadow: 0 40px 80px -32px rgba(15, 23, 42, 0.7);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, rgba(124, 58, 237, 0.2), transparent 55%),
+    radial-gradient(circle at top right, rgba(59, 130, 246, 0.12), transparent 45%), var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+  backdrop-filter: blur(12px);
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 40px 32px;
+  background: linear-gradient(160deg, rgba(24, 33, 54, 0.85), rgba(14, 22, 41, 0.95));
+  border-right: 1px solid var(--border);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.logo {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #7c3aed, #4f46e5);
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.brand strong {
+  font-size: 1.1rem;
+}
+
+.brand small {
+  color: var(--text-soft);
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar-nav a {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 16px;
+  text-decoration: none;
+  border-radius: 14px;
+  background: transparent;
+  color: inherit;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.sidebar-nav a:hover {
+  background: rgba(255, 255, 255, 0.05);
+  transform: translateX(6px);
+}
+
+.sidebar-nav a.active {
+  background: rgba(124, 58, 237, 0.12);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.btn-outline {
+  background: transparent;
+  border: 1px solid rgba(124, 58, 237, 0.45);
+  color: inherit;
+  padding: 12px 18px;
+  border-radius: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.3s ease, border 0.3s ease;
+}
+
+.btn-outline:hover {
+  transform: translateY(-2px);
+  border-color: rgba(124, 58, 237, 0.8);
+}
+
+.content {
+  padding: 40px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--text-soft);
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.btn-ghost {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: inherit;
+  padding: 10px 12px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.3s ease, border 0.3s ease;
+}
+
+.btn-ghost:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.profile-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  font-weight: 600;
+}
+
+.quick-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.quick-link {
+  border: none;
+  border-radius: 16px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  transition: transform 0.3s ease, background 0.3s ease, border 0.3s ease;
+  border: 1px solid transparent;
+}
+
+.quick-link .icon {
+  font-size: 1.2rem;
+}
+
+.quick-link:hover {
+  transform: translateY(-3px);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.quick-link.active {
+  background: rgba(124, 58, 237, 0.15);
+  border-color: rgba(124, 58, 237, 0.4);
+  box-shadow: 0 20px 40px -24px rgba(124, 58, 237, 0.9);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.card {
+  border-radius: 24px;
+  padding: 24px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 20px;
+}
+
+.card.focus {
+  border-color: rgba(124, 58, 237, 0.5);
+  box-shadow: 0 32px 64px -36px rgba(124, 58, 237, 0.8);
+  transform: translateY(-4px);
+}
+
+.card header,
+.card footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--text-soft);
+}
+
+.card .value {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.label {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.pill.positive {
+  background: rgba(16, 185, 129, 0.16);
+  color: #6ee7b7;
+}
+
+.pill.negative {
+  background: rgba(249, 115, 22, 0.16);
+  color: #fcd34d;
+}
+
+.pill.warning {
+  background: rgba(250, 204, 21, 0.16);
+  color: #fde68a;
+}
+
+.secondary {
+  color: var(--text-soft);
+}
+
+.grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.panel {
+  border-radius: 24px;
+  padding: 28px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 20px;
+}
+
+.panel.chart {
+  position: relative;
+}
+
+.panel.chart canvas {
+  width: 100%;
+  height: 260px;
+  border-radius: 18px;
+  background: rgba(8, 12, 24, 0.35);
+  display: block;
+}
+
+.panel.chart canvas:focus-visible {
+  outline: 2px solid rgba(124, 58, 237, 0.6);
+  outline-offset: 4px;
+}
+
+.panel header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.chip-group {
+  display: inline-flex;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 4px;
+}
+
+.chip {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.chip.active {
+  background: rgba(124, 58, 237, 0.2);
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 12px;
+  text-align: center;
+}
+
+.calendar-cell {
+  border-radius: 16px;
+  padding: 14px 10px;
+  display: grid;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid transparent;
+  transition: transform 0.3s ease, border 0.3s ease;
+  cursor: pointer;
+}
+
+.calendar-cell.is-out {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.calendar-cell:hover,
+.calendar-cell.active {
+  transform: translateY(-3px);
+  border-color: rgba(124, 58, 237, 0.4);
+}
+
+.calendar-cell .date {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.calendar-cell .amount {
+  font-size: 0.85rem;
+  color: var(--text-soft);
+}
+
+.calendar-cell .badges {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+}
+
+.dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.dot.positive {
+  background: var(--positive);
+}
+
+.dot.negative {
+  background: var(--negative);
+}
+
+.dot.warning {
+  background: var(--warning);
+}
+
+.calendar-legend {
+  display: flex;
+  gap: 16px;
+  color: var(--text-soft);
+  font-size: 0.85rem;
+}
+
+.calendar-details {
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.calendar-details ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.calendar-details li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}
+
+.calendar-details .amount {
+  font-weight: 600;
+}
+
+.calendar-details .amount.positive {
+  color: var(--positive);
+}
+
+.calendar-details .amount.negative {
+  color: #fca5a5;
+}
+
+.calendar-details .amount.warning {
+  color: var(--warning);
+}
+
+.activity .timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px;
+  align-items: center;
+}
+
+.timeline-item::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 6px rgba(124, 58, 237, 0.18);
+}
+
+.timeline-item strong {
+  font-weight: 600;
+}
+
+.timeline-item span.meta {
+  color: var(--text-soft);
+  font-size: 0.85rem;
+}
+
+.timeline-item .amount {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.timeline-item .amount.entrada {
+  color: var(--positive);
+}
+
+.timeline-item .amount.saida,
+.timeline-item .amount.contas {
+  color: #fda4af;
+}
+
+.chart-tooltip {
+  position: fixed;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.92);
+  color: var(--text);
+  box-shadow: 0 24px 48px -28px rgba(15, 23, 42, 0.9);
+  font-size: 0.8rem;
+  opacity: 0;
+  transform: translate(-9999px, -9999px);
+  transition: opacity 0.15s ease;
+  z-index: 999;
+}
+
+.chart-tooltip.visible {
+  opacity: 1;
+}
+
+.chart-tooltip strong {
+  display: block;
+  font-size: 0.9rem;
+  margin-bottom: 4px;
+}
+
+.chart-tooltip span {
+  display: block;
+  color: var(--text-soft);
+  font-size: 0.75rem;
+}
+
+body.light .chart-tooltip {
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--text);
+}
+
+body.light .chart-tooltip span {
+  color: var(--text-soft);
+}
+
+body.light {
+  color-scheme: light;
+  --bg: #eef2ff;
+  --bg-panel: rgba(255, 255, 255, 0.9);
+  --border: rgba(15, 23, 42, 0.08);
+  --text: #0f172a;
+  --text-soft: #475569;
+  --accent: #4f46e5;
+  --accent-soft: rgba(79, 70, 229, 0.16);
+  --positive: #059669;
+  --negative: #f97316;
+  --warning: #facc15;
+  --shadow: 0 30px 60px -28px rgba(30, 41, 59, 0.22);
+  background: radial-gradient(circle at top left, rgba(79, 70, 229, 0.15), transparent 55%),
+    radial-gradient(circle at top right, rgba(14, 165, 233, 0.12), transparent 45%), var(--bg);
+}
+
+body.light .sidebar {
+  background: linear-gradient(150deg, rgba(237, 233, 254, 0.92), rgba(224, 231, 255, 0.95));
+  border-right: 1px solid var(--border);
+}
+
+body.light .btn-ghost {
+  background: rgba(15, 23, 42, 0.04);
+  border-color: rgba(15, 23, 42, 0.08);
+}
+
+body.light .profile-card {
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+}
+
+body.light .quick-link {
+  background: rgba(255, 255, 255, 0.88);
+}
+
+body.light .quick-link.active {
+  background: rgba(79, 70, 229, 0.2);
+  box-shadow: 0 20px 40px -24px rgba(79, 70, 229, 0.4);
+}
+
+body.light .card,
+body.light .panel {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+body.light .panel.chart canvas {
+  background: rgba(15, 23, 42, 0.06);
+}
+
+@media (max-width: 1180px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+  }
+
+  .content {
+    padding: 32px;
+  }
+}
+
+@media (max-width: 900px) {
+  .sidebar {
+    display: none;
+  }
+
+  .content {
+    padding: 24px;
+  }
+
+  .cards {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .top-bar {
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
+  }
+
+  .quick-links {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the dashboard XAML into an adaptive two-pane layout with hero metrics, filters, charts, and expanded resumo insights
- add a calendar sidebar with month navigation, day selection, and a daily transaction drawer powered by updated home view-model logic
- extend the data layer with calendar-aware collections, category breakdown modeling, and calendar selection cues shared across dashboard and calendar screens

## Testing
- dotnet build src/FinaceDavid.App/FinaceDavid.App.csproj *(fails: dotnet command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e5a34fbd84832e874c10c947ef28a9